### PR TITLE
Fix Signed Value Overflow

### DIFF
--- a/Sources/Eth/EthWord.swift
+++ b/Sources/Eth/EthWord.swift
@@ -38,18 +38,15 @@ public struct EthWord: Codable, Equatable, Hashable, CustomStringConvertible, Ex
         self.init(dataExtending: value.serialize())
     }
 
-    /*
-     import Eth
-     import BigInt
-     EthWord(fromBigInt: BigInt(-1))?.description
-     EthWord(fromBigInt: BigInt(-2))?.description
-     EthWord(fromBigInt: BigInt(-2))?.description
-     */
     public init?(fromBigInt value: BigInt) {
         var data: Data
 
         if value.sign == .plus {
-            data = value.serialize()
+            data = value.serialize().dropFirst(1)
+            if data.count == 32, let msb = data.first, msb & 0x80 != 0 {
+                // Positive signed value overflow
+                return nil
+            }
         } else {
             // Calculate the two's complement for negative values
             var serialized = (-(value + 1)).serialize().dropFirst(1)
@@ -117,13 +114,6 @@ public struct EthWord: Codable, Equatable, Hashable, CustomStringConvertible, Ex
             return BigInt(data)
         }
     }
-
-    // EthWord(hex: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE")!.toBigInt().description
-    // EthWord(hex: "0x8000000000000000000000000000000000000000000000000000000000000000")!.toBigInt().description
-
-    // Functions we need:
-    //   EthWord (two's complemented serialized) -> BigInt toBigInt()
-    //   BigInt -> EthWord (two's complement serialized)   init(fromBigInt:)
 
     public func toInt() -> Int? {
         let bigInt = toBigUInt()

--- a/Tests/EthTests/EVMTests.swift
+++ b/Tests/EthTests/EVMTests.swift
@@ -2,8 +2,11 @@ import BigInt
 @testable import Eth
 import XCTest
 
-private func word(_ data: Int) -> EthWord {
-    EthWord(fromBigInt: BigInt(data))!
+private func word(_ x: Int) -> EthWord {
+    guard let ethWord = EthWord(fromBigInt: BigInt(x)) else {
+        fatalError("Invalid word in EVMTest \(x)")
+    }
+    return ethWord
 }
 
 private func hex(_ data: String) -> Data {

--- a/Tests/EthTests/EthWordTests.swift
+++ b/Tests/EthTests/EthWordTests.swift
@@ -11,11 +11,25 @@ final class EthWordTests: XCTestCase {
         XCTAssertNil(EthWord(hex: "0xaa"))
     }
 
+    func testInitFromBigUInt() throws {
+        XCTAssertEqual(EthWord(fromBigUInt: BigUInt(0))!, EthWord(hex: "0x0000000000000000000000000000000000000000000000000000000000000000"))
+        XCTAssertEqual(EthWord(fromBigUInt: BigUInt(1))!, EthWord(hex: "0x0000000000000000000000000000000000000000000000000000000000000001"))
+        XCTAssertEqual(EthWord(fromBigUInt: BigUInt(2))!, EthWord(hex: "0x0000000000000000000000000000000000000000000000000000000000000002"))
+        XCTAssertEqual(EthWord(fromBigUInt: BigUInt(256))!, EthWord(hex: "0x0000000000000000000000000000000000000000000000000000000000000100"))
+        XCTAssertEqual(EthWord(fromBigUInt: BigUInt(257))!, EthWord(hex: "0x0000000000000000000000000000000000000000000000000000000000000101"))
+        XCTAssertEqual(EthWord(fromBigUInt: (BigUInt(1) << 256) - 1)!, EthWord(hex: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"))
+    }
+
     func testInitFromBigInt() throws {
+        XCTAssertEqual(EthWord(fromBigInt: BigInt(0))!, EthWord(hex: "0x0000000000000000000000000000000000000000000000000000000000000000"))
         XCTAssertEqual(EthWord(fromBigInt: BigInt(-1))!, EthWord(hex: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"))
         XCTAssertEqual(EthWord(fromBigInt: BigInt(-2))!, EthWord(hex: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE"))
         XCTAssertEqual(EthWord(fromBigInt: BigInt(-256))!, EthWord(hex: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00"))
         XCTAssertEqual(EthWord(fromBigInt: BigInt(-257))!, EthWord(hex: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFF"))
+        // Largest valid signed value
+        XCTAssertEqual(EthWord(fromBigInt: (BigInt(1) << 255) - 1)!, EthWord(hex: "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"))
+        // Signed value overflow
+        XCTAssertNil(EthWord(fromBigInt: (BigInt(1) << 255) + 1))
     }
 
     func testToBigInt() throws {


### PR DESCRIPTION
Then converting from a BigInt, the first byte is the sign byte, which needs to be dropped before we deserialize the value, otherwise a large valid value `BigInt(1) << 255 - 1` which serializes to `0x007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff` actually overflows (it's 33 bytes).

But there's an odd case where `BigInt(1) << 255 + 1` serializes to `0x008000000000000000000000000000000000000000000000000000000000000001`, which when we drop the first byte is `0x8000000000000000000000000000000000000000000000000000000000000001` which ends up actually being in the negative space (since the MSB is set), which means we've accidentally overflowed. This code adds a check for that and properly returns nil in this case.