### PR TITLE
Add Swift Syntax

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5eda120ae32396c742a5e132044dc23639fa93c3ce6794b6c2828f66e74806ca",
+  "originHash" : "b01c463f170805af626882ffacedbaefefb4de4250738b1838d034fccbb11498",
   "pins" : [
     {
       "identity" : "bigint",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "0ed110f7555c34ff468e72e1686e59721f2b0da6",
         "version" : "5.3.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
+        "version" : "510.0.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,10 @@ let package = Package(
             name: "Eth",
             targets: ["Eth"]
         ),
+        .executable(
+            name: "EthCodeGen",
+            targets: ["ABIGen"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/attaswift/BigInt.git", from: "5.3.0"),
@@ -27,7 +31,7 @@ let package = Package(
             name: "Eth",
             dependencies: ["BigInt", "SwiftKeccak"]
         ),
-        .target(
+        .executableTarget(
             name: "ABIGen",
             dependencies: [
                 "Eth",

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "Eth",
+    platforms: [
+        .macOS(.v10_15),
+    ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
@@ -15,6 +18,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/attaswift/BigInt.git", from: "5.3.0"),
         .package(url: "https://github.com/bitflying/SwiftKeccak.git", from: "0.1.0"),
+        .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.2"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -23,9 +27,21 @@ let package = Package(
             name: "Eth",
             dependencies: ["BigInt", "SwiftKeccak"]
         ),
+        .target(
+            name: "ABIGen",
+            dependencies: [
+                "Eth",
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
+                .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
+            ]
+        ),
         .testTarget(
             name: "EthTests",
             dependencies: ["Eth"]
+        ),
+        .testTarget(
+            name: "ABIGenTests",
+            dependencies: ["ABIGen", "Eth"]
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ For testing with EVM debug information:
 swift test -Xswiftc -DDEBUG_EVM
 ```
 
+## Generating Swift from ABI
+
+To generate Swift files from ABI json files (e.g. the `out/` directory of forge build), run:
+
+```
+swift run EthCodeGen Tests/Solidity/out/Cool.sol/Cool.json --outDir Tests/Gen
+```
+
 ## Compliance Tests
 
 Compliance tests are Solidity tests which log their results. We then compare the output of the Eth.swift EVM to those results to ensure compliance over a variety of real Solidity contracts.

--- a/Sources/ABIGen/CodeGen.swift
+++ b/Sources/ABIGen/CodeGen.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
@@ -5,6 +6,18 @@ extension String {
     func withFirstLetterUppercased() -> String {
         guard let first = first else { return self }
         return first.uppercased() + dropFirst()
+    }
+}
+
+func writeStringToFile(_ content: String, to filePath: String) -> Bool {
+    let url = URL(fileURLWithPath: filePath)
+
+    do {
+        try content.write(to: url, atomically: true, encoding: .utf8)
+        return true
+    } catch {
+        print("Failed to write to file: \(error)")
+        return false
     }
 }
 
@@ -34,4 +47,9 @@ func generateSwift() -> String {
     }
 
     return source.formatted().description
+}
+
+func generateSwiftFile(input _: URL, outputDir: URL, prefix _: String? = nil) {
+    let filePath = outputDir.appendingPathComponent("Cool.swift")
+    _ = writeStringToFile(generateSwift(), to: filePath.path)
 }

--- a/Sources/ABIGen/CodeGen.swift
+++ b/Sources/ABIGen/CodeGen.swift
@@ -9,16 +9,16 @@ extension String {
     }
 }
 
-func writeStringToFile(_ content: String, to filePath: String) -> Bool {
-    let url = URL(fileURLWithPath: filePath)
+func replaceFileExtension(of fileName: String, with newExtension: String) -> String {
+    let fileURL = URL(fileURLWithPath: fileName)
+    let fileNameWithoutExtension = fileURL.deletingPathExtension().lastPathComponent
+    let newFileName = "\(fileNameWithoutExtension).\(newExtension)"
+    return newFileName
+}
 
-    do {
-        try content.write(to: url, atomically: true, encoding: .utf8)
-        return true
-    } catch {
-        print("Failed to write to file: \(error)")
-        return false
-    }
+func writeStringToFile(_ content: String, to filePath: String) throws {
+    let url = URL(fileURLWithPath: filePath)
+    try content.write(to: url, atomically: true, encoding: .utf8)
 }
 
 func generateSwift() -> String {
@@ -49,7 +49,10 @@ func generateSwift() -> String {
     return source.formatted().description
 }
 
-func generateSwiftFile(input _: URL, outputDir: URL, prefix _: String? = nil) {
-    let filePath = outputDir.appendingPathComponent("Cool.swift")
-    _ = writeStringToFile(generateSwift(), to: filePath.path)
+func generateSwiftFile(input: URL, outputDir: URL, prefix _: String? = nil) throws {
+    let fileName = input.lastPathComponent
+    let outFileName = replaceFileExtension(of: fileName, with: "swift")
+    let filePath = outputDir.appendingPathComponent(outFileName)
+    print("outFile: \(filePath)")
+    try writeStringToFile(generateSwift(), to: filePath.path)
 }

--- a/Sources/ABIGen/CodeGen.swift
+++ b/Sources/ABIGen/CodeGen.swift
@@ -1,0 +1,37 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+extension String {
+    func withFirstLetterUppercased() -> String {
+        guard let first = first else { return self }
+        return first.uppercased() + dropFirst()
+    }
+}
+
+func generateSwift() -> String {
+    let properties = [
+        "firstName": "String",
+        "lastName": "String",
+        "age": "Int",
+    ]
+
+    let source = SourceFileSyntax {
+        StructDeclSyntax(name: "Person") {
+            for (propertyName, propertyType) in properties {
+                DeclSyntax("var \(raw: propertyName): \(raw: propertyType)")
+
+                DeclSyntax(
+                    """
+                    func with\(raw: propertyName.withFirstLetterUppercased())(_ \(raw: propertyName): \(raw: propertyType)) -> Person {
+                      var result = self
+                      result.\(raw: propertyName) = \(raw: propertyName)
+                      return result
+                    }
+                    """
+                )
+            }
+        }
+    }
+
+    return source.formatted().description
+}

--- a/Sources/ABIGen/main.swift
+++ b/Sources/ABIGen/main.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+func main() {
+    let arguments = CommandLine.arguments
+
+    guard arguments.count > 1 else {
+        print("Usage: YourCLI <filePath> --outDir <outDir> --prefix <prefix>")
+        return
+    }
+
+    var filePath: String?
+    var outDir: String?
+    var prefix: String?
+
+    var i = 1
+    while i < arguments.count {
+        switch arguments[i] {
+        case "--outDir":
+            if i + 1 < arguments.count {
+                outDir = arguments[i + 1]
+                i += 1
+            } else {
+                print("Error: --outDir requires a value")
+                return
+            }
+        case "--prefix":
+            if i + 1 < arguments.count {
+                prefix = arguments[i + 1]
+                i += 1
+            } else {
+                print("Error: --prefix requires a value")
+                return
+            }
+        default:
+            if filePath == nil {
+                filePath = arguments[i]
+            } else {
+                print("Error: Unknown argument \(arguments[i])")
+                return
+            }
+        }
+        i += 1
+    }
+
+    guard let inputFilePath = filePath else {
+        print("Error: Missing input file path")
+        return
+    }
+
+    guard let outputDirectory = outDir else {
+        print("Error: Missing output directory")
+        return
+    }
+
+    let inputFullPath = URL(fileURLWithPath: inputFilePath).standardizedFileURL
+    let outputFullPath = URL(fileURLWithPath: outputDirectory).standardizedFileURL
+
+    // Your code to handle the file with the specified options
+    print("Input file path: \(inputFullPath)")
+    print("Output directory: \(outputFullPath)")
+    print("File prefix: \(prefix ?? "")")
+
+    generateSwiftFile(input: inputFullPath, outputDir: outputFullPath)
+}
+
+main()

--- a/Sources/ABIGen/main.swift
+++ b/Sources/ABIGen/main.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-func main() {
+func main() throws {
     let arguments = CommandLine.arguments
 
     guard arguments.count > 1 else {
@@ -60,7 +60,7 @@ func main() {
     print("Output directory: \(outputFullPath)")
     print("File prefix: \(prefix ?? "")")
 
-    generateSwiftFile(input: inputFullPath, outputDir: outputFullPath)
+    try generateSwiftFile(input: inputFullPath, outputDir: outputFullPath)
 }
 
-main()
+try main()

--- a/Tests/ABIGenTests/CodeGenTests.swift
+++ b/Tests/ABIGenTests/CodeGenTests.swift
@@ -1,0 +1,8 @@
+@testable import ABIGen
+import XCTest
+
+final class CodeGenTests: XCTestCase {
+    func testGenerateSwift() throws {
+        XCTAssertEqual(generateSwift(), "Hello")
+    }
+}

--- a/Tests/Gen/Cool.swift
+++ b/Tests/Gen/Cool.swift
@@ -1,0 +1,20 @@
+struct Person {
+    var firstName: String
+    func withFirstName(_ firstName: String) -> Person {
+      var result = self
+      result.firstName = firstName
+      return result
+    }
+    var age: Int
+    func withAge(_ age: Int) -> Person {
+      var result = self
+      result.age = age
+      return result
+    }
+    var lastName: String
+    func withLastName(_ lastName: String) -> Person {
+      var result = self
+      result.lastName = lastName
+      return result
+    }
+}

--- a/Tests/Gen/Cool.swift
+++ b/Tests/Gen/Cool.swift
@@ -1,8 +1,8 @@
 struct Person {
-    var firstName: String
-    func withFirstName(_ firstName: String) -> Person {
+    var lastName: String
+    func withLastName(_ lastName: String) -> Person {
       var result = self
-      result.firstName = firstName
+      result.lastName = lastName
       return result
     }
     var age: Int
@@ -11,10 +11,10 @@ struct Person {
       result.age = age
       return result
     }
-    var lastName: String
-    func withLastName(_ lastName: String) -> Person {
+    var firstName: String
+    func withFirstName(_ firstName: String) -> Person {
       var result = self
-      result.lastName = lastName
+      result.firstName = firstName
       return result
     }
 }

--- a/Tests/Solidity/src/Cool.sol
+++ b/Tests/Solidity/src/Cool.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+contract Cool {
+    function sum(uint256 x, uint256 y) pure external returns (uint256) {
+        return x + y;
+    }
+}


### PR DESCRIPTION
This patch adds Swift Syntax. We add it to a new package `ABIGen`, so that it doesn't become a downstream dependency since it will likely end up as a separate CLI tool. The `ABI` code itself should live in Eth, but the CodeGen will be separate. We show that we _can_, in fact, produce Swift code using Apple-supporting tooling.