### PR TITLE
Add Docc Documentation

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [Eth]

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b01c463f170805af626882ffacedbaefefb4de4250738b1838d034fccbb11498",
+  "originHash" : "9f85554a4a0b64f47a400654df21b6acfd91945f79d2d9fccb397e4c9f1ad535",
   "pins" : [
     {
       "identity" : "bigint",
@@ -8,6 +8,24 @@
       "state" : {
         "revision" : "0ed110f7555c34ff468e72e1686e59721f2b0da6",
         "version" : "5.3.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
         .package(url: "https://github.com/attaswift/BigInt.git", from: "5.3.0"),
         .package(url: "https://github.com/bitflying/SwiftKeccak.git", from: "0.1.0"),
         .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.2"),
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Sources/Eth/ABI/Function.swift
+++ b/Sources/Eth/ABI/Function.swift
@@ -2,17 +2,36 @@ import Foundation
 import SwiftKeccak
 
 public extension ABI {
+    /// Errors that can occur when working with ABI functions.
     enum FunctionError: Error, Equatable {
+        /// Error indicating that the function input is invalid.
+        /// - Parameters:
+        ///   - expected: The expected input schema.
+        ///   - received: The received input schema.
         case invalidFunctionInput(ABI.Schema, ABI.Schema)
+
+        /// Error indicating that the function output is invalid.
+        /// - Parameters:
+        ///   - expected: The expected output schema.
+        ///   - received: The received output schema.
         case invalidFunctionOutput(ABI.Schema, ABI.Schema)
+
+        /// A general error with a message.
+        /// - Parameter message: The error message.
         case unexpectedError(String)
     }
 
+    /// Represents an ABI function with a name, input schemas, and output schemas.
     struct Function: Equatable, CustomStringConvertible {
         public let name: String
         public let inputs: [ABI.Schema]
         public let outputs: [ABI.Schema]
 
+        /// Initializes a new `Function`.
+        /// - Parameters:
+        ///   - name: The name of the function.
+        ///   - inputs: The input schemas for the function.
+        ///   - outputs: The output schemas for the function.
         public init(name: String, inputs: [ABI.Schema], outputs: [ABI.Schema]) {
             self.name = name
             self.inputs = inputs
@@ -27,19 +46,26 @@ public extension ABI {
             .tuple(outputs)
         }
 
+        /// The signature of the function.
         public var signature: String {
             "\(name)\(inputTuple.canonical)"
         }
 
+        /// A description of the function, which is its signature.
         public var description: String {
             signature
         }
 
+        /// The hash of the function's signature.
         public var signatureHash: Data {
             // TODO: handle unwraps !!
             SwiftKeccak.keccak256(signature.data(using: .utf8)!).subdata(in: 0 ..< 4)
         }
 
+        /// Encodes the function with the provided fields.
+        /// - Parameter fields: The fields to encode.
+        /// - Throws: `FunctionError.invalidFunctionInput` if the field types do not match the input tuple.
+        /// - Returns: The encoded data.
         public func encoded(with fields: [Field]) throws -> Data {
             let fieldTuple = Field.tupleN(fields)
             guard fieldTuple.fieldType == inputTuple else {
@@ -48,6 +74,10 @@ public extension ABI {
             return signatureHash + fieldTuple.encoded
         }
 
+        /// Decodes the function's output data.
+        /// - Parameter data: The data to decode.
+        /// - Throws: `FunctionError.invalidFunctionOutput` if the decoded field type does not match the output tuple.
+        /// - Returns: The decoded field.
         public func decode(output data: Data) throws -> Field {
             let res = try outputTuple.decode(data)
             guard res.fieldType == outputTuple else {

--- a/Sources/Eth/ABI/Schema.swift
+++ b/Sources/Eth/ABI/Schema.swift
@@ -2,6 +2,23 @@ import BigInt
 import Foundation
 
 public extension ABI {
+    /**
+     An enumeration of errors that can occur during decoding.
+
+     - insufficientData: The data provided is insufficient for decoding the schema.
+     - excessData: There is excess data left after decoding the schema.
+     - nonEmptyDataFound: Data is found when none was expected.
+     - integerOverflow: An integer overflow occurred during decoding.
+     - sizedUnsignedIntegerOverflow: An overflow occurred for a sized unsigned integer.
+     - sizedSignedIntegerOverflow: An overflow occurred for a sized signed integer.
+     - invalidDataPointer: The data pointer is invalid.
+     - invalidDataHeapPointer: The data heap pointer is invalid.
+     - invalidUtf8String: The UTF-8 string is invalid.
+     - invalidAddress: The address is invalid.
+     - unexpectedError: An unexpected error occurred.
+     - mismatchedType: The types provided do not match the schema.
+     - invalidResponse: The response is invalid.
+     */
     enum DecodeError: Error, Equatable {
         case insufficientData(Schema, Data)
         case excessData(Schema, Data)
@@ -18,6 +35,9 @@ public extension ABI {
         case invalidResponse
     }
 
+    /**
+     An enumeration of all possible Solidity ABI types (e.g. `.uint256` for "uint256", `.tuple([.array(.string)])` for "(string[])")
+     */
     enum Schema: Equatable, CustomStringConvertible {
         // Unsigned Int
         case uint8
@@ -428,6 +448,13 @@ public extension ABI {
             return fields
         }
 
+        /**
+         Decodes the provided data into a `Field` based on the schema.
+
+         - Parameter data: The data to decode.
+         - Throws: `DecodeError` if the decoding fails.
+         - Returns: A `Field` object representing the decoded data.
+         */
         public func decode(_ data: Data) throws -> Field {
             switch self {
             case .uint8:

--- a/Sources/Eth/EVM.swift
+++ b/Sources/Eth/EVM.swift
@@ -11,6 +11,7 @@ public enum EVM {
     static let wordZero = EthWord(fromBigInt: .zero)!
 
     public enum VMError: Error, Equatable {
+        /// Errors that can occur during the execution of the EVM.
         case stackUnderflow
         case stackOverflow
         case pcOutOfBounds
@@ -23,6 +24,7 @@ public enum EVM {
     }
 
     public enum CodeError: Error, Equatable {
+        /// Errors that can occur related to EVM code.
         case outOfBounds
         case invalidOpcode(UInt8)
     }
@@ -31,6 +33,11 @@ public enum EVM {
         let data: Data
         let value: BigUInt
 
+        /// Reads data from the call input with zero padding if necessary.
+        /// - Parameters:
+        ///   - offset: The starting point to read the data.
+        ///   - bytes: The number of bytes to read.
+        /// - Returns: The requested data with zero padding if out of bounds.
         func readData(offset: Int, bytes: Int) -> Data {
             EVM.readZeroPaddedData(offset: offset, bytes: bytes, fromData: data)
         }
@@ -62,6 +69,8 @@ public enum EVM {
         let code: Code
         var opMap: [Int: Operation]
 
+        /// Initializes the EVM context with the provided code.
+        /// - Parameter code: The code to execute in the EVM.
         init(withCode code: Code) {
             self.code = code
             opMap = Context.buildOpMap(code: code)
@@ -1244,6 +1253,11 @@ public enum EVM {
         #endif
     }
 
+    /// Executes the Ethereum Virtual Machine (EVM) with the given code and input.
+    /// - Parameters:
+    ///   - code: The bytecode to be executed.
+    ///   - input: The input data for the execution.
+    /// - Returns: The result of the execution.
     public static func execVm(code: Code, withInput input: CallInput) throws -> ExecutionResult {
         var context = Context(withCode: code)
         while !context.halted {

--- a/Sources/Eth/Eth.docc/Eth.md
+++ b/Sources/Eth/Eth.docc/Eth.md
@@ -1,22 +1,10 @@
-# Eth.swift
+# ``Eth``
 
-A lightweight Ethereum library in Swift.
+`Eth.swift` is a very lightweight Ethereum library in Swift.
 
-## Running Tests
+## Overview
 
-Run the tests using `swift test`, preferably with `xcbeautify`:
-
-```sh
-swift test | xcbeautify
-```
-
-(install xcbeautify via `brew install xcbeautify`)
-
-For testing with EVM debug information:
-
-```sh
-swift test -Xswiftc -DDEBUG_EVM
-```
+`Eth.swift` supports ABI encoding and decoding and has a custom `EVM` which can run pure Ethereum code locally. Currently `Eth.swift` does not support any advanced features such as `JSON-RPC` or other common Ethereum features.
 
 ## Usage
 
@@ -39,13 +27,6 @@ case let .tuple1(.array(_, words)):
 default:
   throw ABI.DecodeError.invalidResponse
 }
-
-## Generating Swift from ABI
-
-To generate Swift files from ABI json files (e.g. the `out/` directory of forge build), run:
-
-```
-swift run Geno Tests/Solidity/out/Cool.sol/Cool.json --outDir Tests/Gen
 ```
 
 As noted above, tuples are generally represented as `.tuple2(.uint8(1), .uint8(2))` to make unwrapping easy. You can also unwrap values using helper methods such as ``ABI/Field/asString``, ``ABI/Field/asBigUInt``, ....
@@ -73,12 +54,9 @@ let result = try! EVM.runQuery(bytecode: code, query: .tuple1(.uint256(22)))
 print("result=" + result.asArray![0].asBigUInt!)
 ```
 
-## Compliance Tests
-
-Compliance tests are Solidity tests which log their results. We then compare the output of the Eth.swift EVM to those results to ensure compliance over a variety of real Solidity contracts.
-
-To build compliance tests, make sure to install `forge` and install submodules `git submodule update --init --recursive` and then run `./Tests/Solidity/build-compliance-tests.sh`. Note: you do not need to run this unless you are editing the Compliance tests.
-
-## Coding Conventions
-
-Please use `swiftformat` on all files before checking in. To install `swiftformat`, run `brew install swiftformat`.
+## Topics
+### Essentials
+- <doc:Hex>
+- <doc:EthAddress>
+- <doc:EVM>
+- <doc:ABI>

--- a/Sources/Eth/EthAddress.swift
+++ b/Sources/Eth/EthAddress.swift
@@ -1,8 +1,13 @@
 import Foundation
 
+/// EthAddress represents a wrapped 20-byte Ethereum address
 public struct EthAddress: Equatable, ExpressibleByStringLiteral {
     let address: Data
 
+    /// Creates an `EthAddress` from a `Data` object.
+    ///
+    /// - Parameter data: The raw data representing the Ethereum address. Must be 20 bytes long.
+    /// - Returns: An optional `EthAddress` if the data is 20 bytes long, otherwise `nil`.
     public init?(_ data: Data) {
         guard data.count == 20 else {
             return nil
@@ -10,6 +15,10 @@ public struct EthAddress: Equatable, ExpressibleByStringLiteral {
         address = data
     }
 
+    /// Creates an `EthAddress` from a hexadecimal string.
+    ///
+    /// - Parameter hex: A string containing the hexadecimal representation of the Ethereum address.
+    /// - Returns: An optional `EthAddress` if the string is a valid 20-byte hex representation, otherwise `nil`.
     public init?(hex: String) {
         guard let data = Hex.parseHex(hex) else {
             return nil
@@ -17,6 +26,10 @@ public struct EthAddress: Equatable, ExpressibleByStringLiteral {
         self.init(data)
     }
 
+    /// Creates an `EthAddress` from a string literal.
+    ///
+    /// - Parameter value: A string literal containing the hexadecimal representation of the Ethereum address.
+    /// - Returns: An `EthAddress` if the string is a valid 20-byte hex representation, otherwise triggers a fatal error.
     public init(stringLiteral value: StringLiteralType) {
         guard let data = Hex.parseHex(value), data.count == 20 else {
             fatalError("Invalid Ethereum Address")

--- a/Sources/Eth/EthWord.swift
+++ b/Sources/Eth/EthWord.swift
@@ -1,9 +1,13 @@
 import BigInt
 import Foundation
 
+/// A 256-bit word used in Ethereum operations, represented by 32 bytes of data.
 public struct EthWord: Codable, Equatable, Hashable, CustomStringConvertible, ExpressibleByStringLiteral {
     let data: Data
 
+    /// Initializes an `EthWord` with a 32-byte data.
+    /// - Parameter data: The data to initialize the `EthWord` with.
+    /// - Returns: An optional `EthWord` instance, or `nil` if the data is not 32 bytes long.
     public init?(_ data: Data) {
         guard data.count == 32 else {
             return nil
@@ -11,6 +15,9 @@ public struct EthWord: Codable, Equatable, Hashable, CustomStringConvertible, Ex
         self.data = data
     }
 
+    /// Initializes an `EthWord` with a hexadecimal string.
+    /// - Parameter hex: The hexadecimal string to initialize the `EthWord` with.
+    /// - Returns: An optional `EthWord` instance, or `nil` if the string cannot be parsed or is not 32 bytes long.
     public init?(hex: String) {
         guard let data = Hex.parseHex(hex) else {
             return nil
@@ -18,6 +25,11 @@ public struct EthWord: Codable, Equatable, Hashable, CustomStringConvertible, Ex
         self.init(data)
     }
 
+    /// Initializes an `EthWord` by extending data with padding to 32 bytes.
+    /// - Parameters:
+    ///   - data: The data to extend.
+    ///   - paddingValue: The value to pad the data with (default is 0).
+    /// - Returns: An optional `EthWord` instance, or `nil` if the data is longer than 32 bytes.
     public init?(dataExtending data: Data, withPadding paddingValue: UInt8 = 0) {
         let paddingSize = 32 - data.count
         guard paddingSize >= 0 else {
@@ -27,6 +39,9 @@ public struct EthWord: Codable, Equatable, Hashable, CustomStringConvertible, Ex
         self.init(padding + data)
     }
 
+    /// Initializes an `EthWord` by extending a hexadecimal string with padding to 32 bytes.
+    /// - Parameter hex: The hexadecimal string to extend.
+    /// - Returns: An optional `EthWord` instance, or `nil` if the string cannot be parsed or the resulting data is longer than 32 bytes.
     public init?(hexExtending hex: String) {
         guard let data = Hex.parseHex(hex) else {
             return nil
@@ -34,10 +49,16 @@ public struct EthWord: Codable, Equatable, Hashable, CustomStringConvertible, Ex
         self.init(dataExtending: data)
     }
 
+    /// Initializes an `EthWord` from a `BigUInt` value.
+    /// - Parameter value: The `BigUInt` value to convert.
+    /// - Returns: An optional `EthWord` instance, or `nil` if the conversion fails.
     public init?(fromBigUInt value: BigUInt) {
         self.init(dataExtending: value.serialize())
     }
 
+    /// Initializes an `EthWord` from a `BigInt` value.
+    /// - Parameter value: The `BigInt` value to convert.
+    /// - Returns: An optional `EthWord` instance, or `nil` if the conversion fails.
     public init?(fromBigInt value: BigInt) {
         var data: Data
 
@@ -57,18 +78,30 @@ public struct EthWord: Codable, Equatable, Hashable, CustomStringConvertible, Ex
         self.init(dataExtending: data, withPadding: value.sign == .plus ? 0x00 : 0xFF)
     }
 
+    /// Initializes an `EthWord` from an `Int` value.
+    /// - Parameter value: The `Int` value to convert.
+    /// - Returns: An optional `EthWord` instance, or `nil` if the conversion fails.
     public init?(fromInt value: Int) {
         self.init(fromBigInt: BigInt(value))
     }
 
+    /// Initializes an `EthWord` from a `UInt` value.
+    /// - Parameter value: The `UInt` value to convert.
+    /// - Returns: An optional `EthWord` instance, or `nil` if the conversion fails.
     public init?(fromUInt value: UInt) {
         self.init(fromBigInt: BigInt(value))
     }
 
+    /// Initializes an `EthWord` from a `UInt8` value.
+    /// - Parameter value: The `UInt8` value to convert.
+    /// - Returns: An optional `EthWord` instance, or `nil` if the conversion fails.
     public init?(fromUInt8 value: UInt8) {
         self.init(fromBigInt: BigInt(value))
     }
 
+    /// Initializes an `EthWord` from a string literal.
+    /// - Parameter value: The string literal to convert.
+    /// - Returns: An `EthWord` instance, or triggers a runtime error if the string is invalid.
     public init(stringLiteral value: StringLiteralType) {
         guard let data = Hex.parseHex(value), data.count == 32 else {
             fatalError("Invalid Ethereum Word: \(value)")
@@ -76,10 +109,13 @@ public struct EthWord: Codable, Equatable, Hashable, CustomStringConvertible, Ex
         self.data = data
     }
 
+    /// A string representation of the `EthWord`.
     public var description: String {
         "EthWord[\(Hex.toShortHex(data))]"
     }
 
+    /// Converts the `EthWord` to a `BigUInt`.
+    /// - Returns: A `BigUInt` representing the `EthWord`.
     public func toBigUInt() -> BigUInt {
         return BigUInt(data)
     }
@@ -94,6 +130,8 @@ public struct EthWord: Codable, Equatable, Hashable, CustomStringConvertible, Ex
         return result
     }
 
+    /// Converts the `EthWord` to a `BigInt`.
+    /// - Returns: A `BigInt` representing the `EthWord`.
     public func toBigInt() -> BigInt {
         // Convert EthWord number to a BigInt
         // As EthWords are stored as two's complement, we will
@@ -119,6 +157,8 @@ public struct EthWord: Codable, Equatable, Hashable, CustomStringConvertible, Ex
         }
     }
 
+    /// Converts the `EthWord` to an `Int`, if possible.
+    /// - Returns: An optional `Int` representing the `EthWord`, or `nil` if the value exceeds `Int.max`.
     public func toInt() -> Int? {
         let bigInt = toBigUInt()
         if bigInt <= BigUInt(Int.max) {

--- a/Sources/Eth/Hex.swift
+++ b/Sources/Eth/Hex.swift
@@ -1,6 +1,27 @@
 import Foundation
 
+/// Hex provides utilities for parsing and encoding hex from and into `Data` values.
 public enum Hex {
+    /// Represents an error parsing hex
+    public enum HexError: Error {
+        case invalidHex(String)
+    }
+
+    /**
+     * Parses a hexadecimal string and returns the corresponding `Data`.
+     *
+     * This method processes both prefixed (`0x`) and non-prefixed hexadecimal strings.
+     *
+     * Example:
+     * ```
+     * if let data = Hex.parseHex("0x0A1B2C") {
+     *     print(data)  // <0a1b2c>
+     * }
+     * ```
+     *
+     * - Parameter hex: The hexadecimal string to parse.
+     * - Returns: The `Data` representation of the hexadecimal string, or `nil` if the string is not valid hexadecimal.
+     */
     public static func parseHex(_ hex: String) -> Data? {
         let hexStringPre = hex.hasPrefix("0x") ? String(hex.dropFirst(2)) : hex
         let hexString = hexStringPre.count % 2 == 0 ? hexStringPre : "0\(hexStringPre)"
@@ -22,10 +43,61 @@ public enum Hex {
         return data
     }
 
+    /**
+     * Parses a hexadecimal string and returns the corresponding `Data` or throws.
+     *
+     * This method processes both prefixed (`0x`) and non-prefixed hexadecimal strings.
+     *
+     * Example:
+     * ```
+     * if let data = try Hex.hex("0x0A1B2C") {
+     *     print(data)  // <0a1b2c>
+     * }
+     * ```
+     *
+     * - Parameter hex: The hexadecimal string to parse.
+     * - Returns: The `Data` representation of the hexadecimal string.
+     */
+    public static func hex(_ hexInput: String) throws -> Data {
+        if let hex = parseHex(hexInput) {
+            hex
+        } else {
+            throw HexError.invalidHex(hexInput)
+        }
+    }
+
+    /**
+     * Converts `Data` to a hexadecimal string with a `0x` prefix.
+     *
+     * Example:
+     * ```
+     * let data = Data([0x0A, 0x1B, 0x2C])
+     * let hexString = Hex.toHex(data)
+     * print(hexString)  // "0x0a1b2c"
+     * ```
+     *
+     * - Parameter data: The `Data` to convert to a hexadecimal string.
+     * - Returns: A hexadecimal string representation of the `Data` with a `0x` prefix.
+     */
     public static func toHex(_ data: Data) -> String {
         return "0x" + data.map { String(format: "%02x", $0) }.joined()
     }
 
+    /**
+     * Converts `Data` to a short hexadecimal string with a `0x` prefix, trimming leading zeros.
+     *
+     * If the `Data` represents zero (i.e., all bytes are zero), the result is `"0x0"`.
+     *
+     * Example:
+     * ```
+     * let data = Data([0x00, 0x01, 0x0A])
+     * let shortHexString = Hex.toShortHex(data)
+     * print(shortHexString)  // "0x10a"
+     * ```
+     *
+     * - Parameter data: The `Data` to convert to a short hexadecimal string.
+     * - Returns: A short hexadecimal string representation of the `Data` with a `0x` prefix.
+     */
     public static func toShortHex(_ data: Data) -> String {
         let hexString = data.map { String(format: "%02x", $0) }.joined()
         let trimmedHexString = hexString.drop { $0 == "0" }

--- a/Tests/EthTests/ABITests.swift
+++ b/Tests/EthTests/ABITests.swift
@@ -394,42 +394,11 @@ func showEncoded(_ encoded: Data) -> String {
     "ABI Encoded ⬇️\n\n\t\t\(EthUtil.showChunkedWords(encoded))\n\n"
 }
 
-func jsonValue(field: ABI.Field) -> String {
-    switch field {
-    case let .uint8(v), let .uint16(v), let .uint24(v), let .uint32(v):
-        return v.description
-    case let .uint40(v), let .uint48(v), let .uint56(v), let .uint64(v), let .uint72(v), let .uint80(v), let .uint88(v), let .uint96(v), let .uint104(v), let .uint112(v), let .uint120(v), let .uint128(v), let .uint136(v), let .uint144(v), let .uint152(v), let .uint160(v), let .uint168(v), let .uint176(v), let .uint184(v), let .uint192(v), let .uint200(v), let .uint208(v), let .uint216(v), let .uint224(v), let .uint232(v), let .uint240(v), let .uint248(v), let .uint256(v):
-        return v.description
-    case let .int8(v), let .int16(v), let .int24(v), let .int32(v):
-        return v.description
-    case let .int40(v), let .int48(v), let .int56(v), let .int64(v), let .int72(v), let .int80(v), let .int88(v), let .int96(v), let .int104(v), let .int112(v), let .int120(v), let .int128(v), let .int136(v), let .int144(v), let .int152(v), let .int160(v), let .int168(v), let .int176(v), let .int184(v), let .int192(v), let .int200(v), let .int208(v), let .int216(v), let .int224(v), let .int232(v), let .int240(v), let .int248(v), let .int256(v):
-        return v.description
-    case let .bool(v):
-        return v.description
-    case let .address(v):
-        return "\"\(Hex.toHex(v.address))\""
-    case let .bytes(d):
-        return "\"\(Hex.toHex(d))\""
-    case let .bytes1(d), let .bytes2(d), let .bytes3(d), let .bytes4(d), let .bytes5(d), let .bytes6(d), let .bytes7(d), let .bytes8(d), let .bytes9(d), let .bytes10(d), let .bytes11(d), let .bytes12(d), let .bytes13(d), let .bytes14(d), let .bytes15(d), let .bytes16(d), let .bytes17(d), let .bytes18(d), let .bytes19(d), let .bytes20(d), let .bytes21(d), let .bytes22(d), let .bytes23(d), let .bytes24(d), let .bytes25(d), let .bytes26(d), let .bytes27(d), let .bytes28(d), let .bytes29(d), let .bytes30(d), let .bytes31(d), let .bytes32(d):
-        return "\"\(Hex.toHex(d))\""
-    case let .string(v):
-        return "\"\(v.description)\""
-    case let .array(_, v):
-        return "'[\(v.map { jsonValue(field: $0) }.joined(separator: ","))]'"
-    case let .arrayN(_, _, v):
-        return "'[\(v.map { jsonValue(field: $0) }.joined(separator: ","))]'"
-    case let .tupleN(v):
-        return "'(\(v.map { jsonValue(field: $0) }.joined(separator: ",")))'"
-    case .tuple0, .tuple1, .tuple2, .tuple3, .tuple4, .tuple5, .tuple6, .tuple7, .tuple8, .tuple9, .tuple10, .tuple11, .tuple12, .tuple13, .tuple14, .tuple15, .tuple16:
-        return jsonValue(field: field.asTupleN!)
-    }
-}
-
 func showHelp(_ field: ABI.Field) -> String? {
     switch field {
     case let .tupleN(fields):
         let fieldTypeStrings = fields.map { $0.fieldType.description }.joined(separator: ", ")
-        let fieldValueStrings = fields.map { jsonValue(field: $0) }.joined(separator: " ")
+        let fieldValueStrings = fields.map { $0.jsonValue }.joined(separator: " ")
         return " - Compare to `cast abi-encode 'tuple(\(fieldTypeStrings))' \(fieldValueStrings)`"
     case .tuple0, .tuple1, .tuple2, .tuple3, .tuple4, .tuple5, .tuple6, .tuple7, .tuple8, .tuple9, .tuple10:
         return showHelp(field.asTupleN!)


### PR DESCRIPTION
This patch adds `docc` documentation, which will act as the public documentation of `EVM.swift`.