### PR TITLE
Rename `ABI.Field` to `ABI.Value`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ swift test -Xswiftc -DDEBUG_EVM
 
 ### ABI
 
-The ``ABI/Schema`` enum defines Ethereum ABI definitions and the ``ABI/Field`` enum defines an decoded value. You can use quickly encode ABI values using the ``ABI/Field/encoded`` computed property:
+The ``ABI/Schema`` enum defines Ethereum ABI definitions and the ``ABI/Value`` enum defines an decoded value. You can use quickly encode ABI values using the ``ABI/Value/encoded`` computed property:
 
 ```swift
-let data: Data = ABI.Field.tuple1(.array(.string, [.string("hello"), .string("world")])).encoded
+let data: Data = ABI.Value.tuple1(.array(.string, [.string("hello"), .string("world")])).encoded
 ```
 
 and use ``ABI/Schema/decode(_:)`` to decode values.
@@ -39,16 +39,19 @@ case let .tuple1(.array(_, words)):
 default:
   throw ABI.DecodeError.invalidResponse
 }
+```
+
+As noted above, tuples are generally represented as `.tuple2(.uint8(1), .uint8(2))` to make unwrapping easy. You can also unwrap values using helper methods such as ``ABI/Value/asString``, ``ABI/Value/asBigUInt``, ....
 
 ## Generating Swift from ABI
 
-To generate Swift files from ABI json files (e.g. the `out/` directory of forge build), run:
+To generate Swift files from ABI json files (e.g. the `out/` directory of `forge build`), run:
 
-```
-swift run Geno Tests/Solidity/out/Cool.sol/Cool.json --outDir Tests/Gen
+```sh
+swift run Geno ./out/Cool.sol/Cool.json --outDir Sources/
 ```
 
-As noted above, tuples are generally represented as `.tuple2(.uint8(1), .uint8(2))` to make unwrapping easy. You can also unwrap values using helper methods such as ``ABI/Field/asString``, ``ABI/Field/asBigUInt``, ....
+It's also suggested you run `swiftformat` on the generated file. See ``Geno`` for more information on code generation.
 
 ### EVM
 

--- a/Sources/Eth/Eth.docc/Eth.md
+++ b/Sources/Eth/Eth.docc/Eth.md
@@ -10,10 +10,10 @@
 
 ### ABI
 
-The ``ABI/Schema`` enum defines Ethereum ABI definitions and the ``ABI/Field`` enum defines an decoded value. You can use quickly encode ABI values using the ``ABI/Field/encoded`` computed property:
+The ``ABI/Schema`` enum defines Ethereum ABI definitions and the ``ABI/Value`` enum defines an decoded value. You can use quickly encode ABI values using the ``ABI/Value/encoded`` computed property:
 
 ```swift
-let data: Data = ABI.Field.tuple1(.array(.string, [.string("hello"), .string("world")])).encoded
+let data: Data = ABI.Value.tuple1(.array(.string, [.string("hello"), .string("world")])).encoded
 ```
 
 and use ``ABI/Schema/decode(_:)`` to decode values.
@@ -29,7 +29,7 @@ default:
 }
 ```
 
-As noted above, tuples are generally represented as `.tuple2(.uint8(1), .uint8(2))` to make unwrapping easy. You can also unwrap values using helper methods such as ``ABI/Field/asString``, ``ABI/Field/asBigUInt``, ....
+As noted above, tuples are generally represented as `.tuple2(.uint8(1), .uint8(2))` to make unwrapping easy. You can also unwrap values using helper methods such as ``ABI/Value/asString``, ``ABI/Value/asBigUInt``, ....
 
 ### EVM
 
@@ -54,9 +54,14 @@ let result = try! EVM.runQuery(bytecode: code, query: .tuple1(.uint256(22)))
 print("result=" + result.asArray![0].asBigUInt!)
 ```
 
+### Geno
+
+For information on Swift code generation for Solidity contracts, see ``Geno``.
+
 ## Topics
 ### Essentials
 - <doc:Hex>
 - <doc:EthAddress>
 - <doc:EVM>
 - <doc:ABI>
+- ``Geno``

--- a/Sources/Geno/Geno.docc/Geno.md
+++ b/Sources/Geno/Geno.docc/Geno.md
@@ -1,0 +1,70 @@
+
+# ``Geno``
+
+Geno is code generator of swift wrappers to Solidity contracts.
+
+## Getting Started
+
+Geno generates Swift code that wraps the usage of Solidity contracts in type-safe Swift. This makes it easy to call and use Solidity contracts in Swift with compile-time guarantees.
+
+First, make sure you have a Solidity ABI json file. For instance, you can use [forge](https://book.getfoundry.sh/) to build a Solidity project into the `out/` directory. Then, you can simply run:
+
+```sh
+swift run Geno ./out/Cool.sol/Cool.json --outDir Sources/
+```
+
+It's also suggested you run [swiftformat](https://github.com/nicklockwood/SwiftFormat) on the generated file.
+
+## Examples
+
+Let's say you have a Solidity file as such:
+
+```js
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+contract Cool {
+    function sum(uint256 x, uint256 y) pure external returns (uint256) {
+        return x + y;
+    }
+}
+```
+
+The output from `Geno` should look something like this:
+
+```swift
+import BigInt
+import Eth
+import Foundation
+
+enum Cool {
+    static let creationCode: Hex = "0x..."
+    static let runtimeCode: Hex = "0x..."
+
+    static let sumFn = ABI.Function(
+        name: "sum",
+        inputs: [.uint256, .uint256],
+        outputs: [.uint256]
+    )
+
+    static func sum(x: BigUInt, y: BigUInt) throws -> BigUInt {
+        let query = try sumFn.encoded(with: [.uint256(x), .uint256(y)])
+        let result = try EVM.runQuery(bytecode: runtimeCode, query: query)
+        let decoded = try sumFn.decode(output: result)
+
+        switch decoded {
+        case let .tuple1(.uint256(var0)):
+            return var0
+        default:
+            throw ABI.DecodeError.mismatchedType(decoded.schema, sumFn.outputTuple)
+        }
+    }
+}
+```
+
+From there, you can start to call into the real functionality of the contract. E.g. to run the `sum` function locally, you can run:
+
+```swift
+> try Cool.sum(x: BigUInt(1000), y: BigUInt(1000))
+BigUInt(2000)
+```

--- a/Tests/EthTests/Example.swift
+++ b/Tests/EthTests/Example.swift
@@ -8,7 +8,7 @@ struct Cat: Equatable {
     let age: UInt
 
     var encoded: Hex {
-        ABI.Field.tuple2(.string(name), .uint8(age)).encoded
+        ABI.Value.tuple2(.string(name), .uint8(age)).encoded
     }
 
     static func decode(hex: Hex) throws -> Cat {
@@ -17,7 +17,7 @@ struct Cat: Equatable {
         case let .tuple2(.string(name), .uint8(age)):
             return Cat(name: name, age: age)
         default:
-            throw ABI.DecodeError.mismatchedType(decoded.fieldType, schema)
+            throw ABI.DecodeError.mismatchedType(decoded.schema, schema)
         }
     }
 }

--- a/Tests/GenoTests/Abi.swift
+++ b/Tests/GenoTests/Abi.swift
@@ -21,7 +21,7 @@ enum Abi {
         case let .tuple1(.bytes(var0)):
             return var0
         default:
-            throw ABI.DecodeError.mismatchedType(decoded.fieldType, abiEncodeSelectorFn.outputTuple)
+            throw ABI.DecodeError.mismatchedType(decoded.schema, abiEncodeSelectorFn.outputTuple)
         }
     }
 
@@ -40,7 +40,7 @@ enum Abi {
         case let .tuple1(.bytes(var0)):
             return var0
         default:
-            throw ABI.DecodeError.mismatchedType(decoded.fieldType, simpleAbiEncodingFn.outputTuple)
+            throw ABI.DecodeError.mismatchedType(decoded.schema, simpleAbiEncodingFn.outputTuple)
         }
     }
 
@@ -59,7 +59,7 @@ enum Abi {
         case let .tuple1(.bytes(var0)):
             return var0
         default:
-            throw ABI.DecodeError.mismatchedType(decoded.fieldType, simpleAbiEncodingPackedFn.outputTuple)
+            throw ABI.DecodeError.mismatchedType(decoded.schema, simpleAbiEncodingPackedFn.outputTuple)
         }
     }
 }

--- a/Tests/GenoTests/Cool.swift
+++ b/Tests/GenoTests/Cool.swift
@@ -21,7 +21,7 @@ enum Cool {
         case let .tuple1(.uint256(var0)):
             return var0
         default:
-            throw ABI.DecodeError.mismatchedType(decoded.fieldType, sumFn.outputTuple)
+            throw ABI.DecodeError.mismatchedType(decoded.schema, sumFn.outputTuple)
         }
     }
 }

--- a/Tests/GenoTests/GenoTest.swift
+++ b/Tests/GenoTests/GenoTest.swift
@@ -13,8 +13,8 @@ final class GenoTests: XCTestCase {
 
         var abiTypes: [String] = []
         for f in contract.abi {
-            let fieldTypes = f.outputs.map { parameterToFieldType($0) }
-            abiTypes.append(contentsOf: fieldTypes)
+            let schemas = f.outputs.map { parameterToValueType($0) }
+            abiTypes.append(contentsOf: schemas)
         }
         let desired = [".int256", ".tuple([.uint96, .uint160, .array(Cat.schema), .string])"]
         for (i, _) in desired.enumerated() {
@@ -31,8 +31,8 @@ final class GenoTests: XCTestCase {
 
         var abiTypes: [String] = []
         for f in contract.abi {
-            let fieldTypes = f.outputs.enumerated().map { i, p in parameterToMatchableFieldType(p: p, index: i) }
-            abiTypes.append(contentsOf: fieldTypes)
+            let schemas = f.outputs.enumerated().map { i, p in parameterToMatchableValueType(p: p, index: i) }
+            abiTypes.append(contentsOf: schemas)
         }
         let desired = [".int256(var0)", ".tuple4(.uint96(a),\n .uint160(b),\n .array(Cat.schema, c),\n .string(d))"]
         for (i, _) in desired.enumerated() {
@@ -70,11 +70,11 @@ final class GenoTests: XCTestCase {
 
         var intializers: [String] = []
         for f in contract.abi {
-            let fieldTypes = f.outputs.enumerated().map { _, p in structInitializer(parameter: p, structName: "Bat") }
-            intializers.append(contentsOf: fieldTypes)
+            let schemas = f.outputs.enumerated().map { _, p in structInitializer(parameter: p, structName: "Bat") }
+            intializers.append(contentsOf: schemas)
         }
 
-        let desired = ["", "try Bat(a: a, b: b, c: c.map { try Cat.decodeField($0) }, d: d)"]
+        let desired = ["", "try Bat(a: a, b: b, c: c.map { try Cat.decodeValue($0) }, d: d)"]
         for (i, _) in desired.enumerated() {
             XCTAssertEqual(intializers[i], desired[i])
         }

--- a/Tests/GenoTests/Structs.swift
+++ b/Tests/GenoTests/Structs.swift
@@ -14,28 +14,28 @@ enum Structs {
         let f: Cat
 
         var encoded: Hex {
-            asField.encoded
+            asValue.encoded
         }
 
-        var asField: ABI.Field {
+        var asValue: ABI.Value {
             .tuple6(.uint96(a),
                     .uint160(b),
                     .array(Cat.schema, c.map {
-                        $0.asField
+                        $0.asValue
                     }),
                     .string(d),
                     .array(.uint256, e.map {
                         .uint256($0)
                     }),
-                    f.asField)
+                    f.asValue)
         }
 
         static func decode(hex: Hex) throws -> Bat {
-            try decodeField(schema.decode(hex))
+            try decodeValue(schema.decode(hex))
         }
 
-        static func decodeField(_ field: ABI.Field) throws -> Bat {
-            switch field {
+        static func decodeValue(_ value: ABI.Value) throws -> Bat {
+            switch value {
             case let .tuple6(.uint96(a),
                              .uint160(b),
                              .array(Cat.schema, c),
@@ -43,12 +43,12 @@ enum Structs {
                              .array(.uint256, e),
                              f):
                 return try Bat(a: a, b: b, c: c.map {
-                    try Cat.decodeField($0)
+                    try Cat.decodeValue($0)
                 }, d: d, e: e.map {
                     $0.asBigUInt!
-                }, f: Cat.decodeField(f))
+                }, f: Cat.decodeValue(f))
             default:
-                throw ABI.DecodeError.mismatchedType(field.fieldType, schema)
+                throw ABI.DecodeError.mismatchedType(value.schema, schema)
             }
         }
     }
@@ -61,27 +61,27 @@ enum Structs {
         let cc: Hex
 
         var encoded: Hex {
-            asField.encoded
+            asValue.encoded
         }
 
-        var asField: ABI.Field {
+        var asValue: ABI.Value {
             .tuple3(.int256(ca),
                     .bytes(cb),
                     .bytes32(cc))
         }
 
         static func decode(hex: Hex) throws -> Cat {
-            try decodeField(schema.decode(hex))
+            try decodeValue(schema.decode(hex))
         }
 
-        static func decodeField(_ field: ABI.Field) throws -> Cat {
-            switch field {
+        static func decodeValue(_ value: ABI.Value) throws -> Cat {
+            switch value {
             case let .tuple3(.int256(ca),
                              .bytes(cb),
                              .bytes32(cc)):
                 return try Cat(ca: ca, cb: cb, cc: cc)
             default:
-                throw ABI.DecodeError.mismatchedType(field.fieldType, schema)
+                throw ABI.DecodeError.mismatchedType(value.schema, schema)
             }
         }
     }
@@ -96,7 +96,7 @@ enum Structs {
     )
 
     static func acceptBat(bat: Bat) throws -> BigInt {
-        let query = try acceptBatFn.encoded(with: [bat.asField])
+        let query = try acceptBatFn.encoded(with: [bat.asValue])
         let result = try EVM.runQuery(bytecode: runtimeCode, query: query)
         let decoded = try acceptBatFn.decode(output: result)
 
@@ -104,7 +104,7 @@ enum Structs {
         case let .tuple1(.int256(var0)):
             return var0
         default:
-            throw ABI.DecodeError.mismatchedType(decoded.fieldType, acceptBatFn.outputTuple)
+            throw ABI.DecodeError.mismatchedType(decoded.schema, acceptBatFn.outputTuple)
         }
     }
 
@@ -126,9 +126,9 @@ enum Structs {
                                  .string(d),
                                  .array(.uint256, e),
                                  f)):
-            return try Bat(a: a, b: b, c: c.map { try Cat.decodeField($0) }, d: d, e: e.map { $0.asBigUInt! }, f: Cat.decodeField(f))
+            return try Bat(a: a, b: b, c: c.map { try Cat.decodeValue($0) }, d: d, e: e.map { $0.asBigUInt! }, f: Cat.decodeValue(f))
         default:
-            throw ABI.DecodeError.mismatchedType(decoded.fieldType, buildBatFn.outputTuple)
+            throw ABI.DecodeError.mismatchedType(decoded.schema, buildBatFn.outputTuple)
         }
     }
 }


### PR DESCRIPTION
The name `ABI.Field` just didn't feel right, so we rename the struct to `ABI.Value` to make it more understandable. We also change `field.fieldType` to `value.schema`, which again, makes a lot more sense. These changes shouldn't otherwise have observable effects.