### PR TITLE
Add Min iOS Version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     name: "Eth",
     platforms: [
         .macOS(.v10_15),
+        .iOS(.v13),
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.


### PR DESCRIPTION
We require iOS 13+ for SwiftSyntax. This specifies that change.