### PR TITLE
Make Inner Datas Public

### DIFF
--- a/Sources/Eth/EthWord.swift
+++ b/Sources/Eth/EthWord.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// A 256-bit (32-byte) word used in Ethereum operations.
 public struct EthWord: Codable, Equatable, Hashable, CustomStringConvertible, ExpressibleByStringLiteral {
-    let hex: Hex
+    public let hex: Hex
 
     /// Initializes an `EthWord` with a 32-byte `Hex` data.
     /// - Parameter hex: The hex data to initialize the `EthWord` with.

--- a/Sources/Eth/Hex.swift
+++ b/Sources/Eth/Hex.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Hex is a light wrapper around `Data` to make it easily convertable to and from hex strings.
 public struct Hex: Codable, Equatable, Hashable, CustomStringConvertible, ExpressibleByStringLiteral {
-    let data: Data
+    public let data: Data
 
     /// Represents an error parsing hex
     public enum HexError: Error, Equatable {


### PR DESCRIPTION
Since structs inner members are not, by default, public externally.