### PR TITLE
Add Encoder and Decoders for Hex and EthAddress

### DIFF
--- a/Sources/Eth/EthAddress.swift
+++ b/Sources/Eth/EthAddress.swift
@@ -46,8 +46,34 @@ public struct EthAddress: Codable, Equatable, Hashable, CustomStringConvertible,
         address = hex
     }
 
+    /// Decodes an `EthAddress` from a hex string
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let data = try container.decode(Hex.self)
+        if data.count != 20 {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "EthAddress must be exactly 20-bytes")
+        }
+        address = data
+    }
+
+    /// Encodes `EthAddress` to a hex string
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(hex)
+    }
+
     /// The address represented as a hexadecimal string.
     public var description: String {
+        hex
+    }
+
+    /// The address represented as a hexadecimal string.
+    public var hex: String {
         address.hex
+    }
+
+    /// The Data represented by this address.
+    public var data: Data {
+        address.data
     }
 }

--- a/Sources/Eth/Hex.swift
+++ b/Sources/Eth/Hex.swift
@@ -39,6 +39,18 @@ public struct Hex: Codable, Equatable, Hashable, CustomStringConvertible, Expres
         self.init(hexData)
     }
 
+    /// Decodes a `Hex` from a hex string
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        data = try Hex.parseHex(container.decode(String.self))
+    }
+
+    /// Encodes `Hex` to a hex string
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(hex)
+    }
+
     /// An empty `Hex` value
     public static var empty = Hex(Data())
 

--- a/Tests/EthTests/EthAddressTests.swift
+++ b/Tests/EthTests/EthAddressTests.swift
@@ -9,4 +9,34 @@ final class EthAddressTests: XCTestCase {
         )
         XCTAssertNil(EthAddress(fromHexString: "0xaa"))
     }
+
+    func testAddressEncodingDecoding() {
+        let address = EthAddress("0xdef1c0ded9bec7f1a1670819833240f027b25eff")
+        let encoder = JSONEncoder()
+        do {
+            let data = try encoder.encode(address)
+
+            let decoder = JSONDecoder()
+            let decodedHex = try decoder.decode(EthAddress.self, from: data)
+
+            XCTAssertEqual(address, decodedHex, "Encoded and decoded values should be equal")
+        } catch {
+            XCTFail("Encoding or decoding failed: \(error)")
+        }
+    }
+
+    func testAddressDecodeInvalidLength() {
+        let hex = Hex("0xdef1c0ded9bec7f1a1670819833240f027b25eff22334455")
+        let encoder = JSONEncoder()
+        do {
+            let data = try encoder.encode(hex)
+
+            let decoder = JSONDecoder()
+            _ = try decoder.decode(EthAddress.self, from: data)
+
+            XCTFail("Should have failed invalid address length")
+        } catch {
+            XCTAssertEqual(error.localizedDescription, "The data couldn’t be read because it isn’t in the correct format.")
+        }
+    }
 }

--- a/Tests/EthTests/HexTests.swift
+++ b/Tests/EthTests/HexTests.swift
@@ -68,4 +68,19 @@ final class HexTests: XCTestCase {
         XCTAssertEqual(Hex("0x0122").shortHex, "0x122")
         XCTAssertEqual(Hex("1122").shortHex, "0x1122")
     }
+
+    func testHexEncodingDecoding() {
+        let hex = Hex("0xdef1c0ded9bec7f1a1670819833240f027b25eff")
+        let encoder = JSONEncoder()
+        do {
+            let data = try encoder.encode(hex)
+
+            let decoder = JSONDecoder()
+            let decodedHex = try decoder.decode(Hex.self, from: data)
+
+            XCTAssertEqual(hex, decodedHex, "Encoded and decoded values should be equal")
+        } catch {
+            XCTFail("Encoding or decoding failed: \(error)")
+        }
+    }
 }


### PR DESCRIPTION
We previously didn't have express encoders and decoders for `Hex` and `EthAddress`. This patch adds these encoders and decoders, which makes these value types easy to use in structs when handling hex or Ethereum addresses.