### PR TITLE
polish geno output by removing library double namespacing and extra trys

### DIFF
--- a/Tests/GenoTests/Cool.swift
+++ b/Tests/GenoTests/Cool.swift
@@ -16,7 +16,7 @@ enum Cool {
         inputs: []
     )
 
-    enum RevertReason: Error {
+    enum RevertReason: Equatable, Error {
         case lukeWarm(Bool)
         case tooCool
         case unknownRevert(String, String)

--- a/Tests/GenoTests/GenoTest.swift
+++ b/Tests/GenoTests/GenoTest.swift
@@ -53,12 +53,15 @@ final class GenoTests: XCTestCase {
         let regex = try! NSRegularExpression(pattern: "struct Bat: Equatable\\{static let schema: ABI\\.Schema = ABI.Schema\\.tuple")
 
         // Perform the matching
-        let testString = structDefs[0].description
+        let testString = structDefs[1].description
         let range = NSRange(location: 0, length: testString.description.utf16.count)
         let match = regex.firstMatch(in: testString, options: [], range: range)
 
         // Assert that a match was found
-        XCTAssertNotNil(match, "The string does not match the regex")
+        XCTAssertNotNil(match, "Bat struct not here")
+
+        let animalRegex = try! NSRegularExpression(pattern: "struct Animal")
+        XCTAssertNotNil(animalRegex.firstMatch(in: structDefs[1].description, options: [], range: range), "NameSpace exists")
     }
 
     func testConstructorForStruct() {
@@ -78,6 +81,9 @@ final class GenoTests: XCTestCase {
         for (i, _) in desired.enumerated() {
             XCTAssertEqual(intializers[i], desired[i])
         }
+
+        let noDangerousChildren = Geno.Contract.ABI.Function.Parameter(name: "", type: "tuple", internalType: "struct Animal.Bat", components: [])
+        XCTAssertEqual(structInitializer(parameter: noDangerousChildren, structName: "Bat"), "Bat()")
     }
 
     func testCallParameters() {
@@ -98,7 +104,7 @@ final class GenoTests: XCTestCase {
                         {
                             "name": "bat",
                             "type": "tuple",
-                            "internalType": "struct Bat",
+                            "internalType": "struct Animal.Bat",
                             "components": [
                                 {
                                     "name": "a",
@@ -168,7 +174,7 @@ final class GenoTests: XCTestCase {
                         {
                             "name": "",
                             "type": "tuple",
-                            "internalType": "struct Bat",
+                            "internalType": "struct Animal.Bat",
                             "components": [
                                 {
                                     "name": "a",

--- a/Tests/GenoTests/Structs.swift
+++ b/Tests/GenoTests/Structs.swift
@@ -79,7 +79,7 @@ enum Structs {
             case let .tuple3(.int256(ca),
                              .bytes(cb),
                              .bytes32(cc)):
-                return try Cat(ca: ca, cb: cb, cc: cc)
+                return Cat(ca: ca, cb: cb, cc: cc)
             default:
                 throw ABI.DecodeError.mismatchedType(value.schema, schema)
             }
@@ -107,7 +107,7 @@ enum Structs {
             static func decodeValue(_ value: ABI.Value) throws -> Animal.Moose {
                 switch value {
                 case let .tuple1(.uint256(b)):
-                    return try Animal.Moose(b: b)
+                    return Animal.Moose(b: b)
                 default:
                     throw ABI.DecodeError.mismatchedType(value.schema, schema)
                 }
@@ -134,7 +134,7 @@ enum Structs {
             static func decodeValue(_ value: ABI.Value) throws -> Animal.Rat {
                 switch value {
                 case let .tuple1(.address(a)):
-                    return try Animal.Rat(a: a)
+                    return Animal.Rat(a: a)
                 default:
                     throw ABI.DecodeError.mismatchedType(value.schema, schema)
                 }
@@ -155,7 +155,7 @@ enum Structs {
         inputs: [.bool]
     )
 
-    enum RevertReason: Error {
+    enum RevertReason: Equatable, Error {
         case justAName
         case justOneArg(Bool)
         case unknownRevert(String, String)


### PR DESCRIPTION
Library's namespace their structs in solidity abis. When the contract has the same name as the library, this resulted in a double namespace for the generated file ( eg some file, Animal.sol, containing a Library Animal and a struct Bat would make Animal.Animal.Bat ). This Geno patch removes the double struct namespacing where it exists, as well as removing warning try's