### PR TITLE
Add Address Checksum

### DIFF
--- a/Sources/Eth/EthAddress.swift
+++ b/Sources/Eth/EthAddress.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftKeccak
 
 /// `EthAddress` represents a 20-byte Ethereum address
 public struct EthAddress: Codable, Equatable, Hashable, CustomStringConvertible, ExpressibleByStringLiteral {
@@ -75,5 +76,29 @@ public struct EthAddress: Codable, Equatable, Hashable, CustomStringConvertible,
     /// The Data represented by this address.
     public var data: Data {
         address.data
+    }
+
+    public var checksum: String {
+        // Remove the '0x' prefix
+        let cleanAddress = String(hex.dropFirst(2))
+
+        // Get the hash of the clean address
+        let hashData = SwiftKeccak.keccak256(cleanAddress)
+
+        // Convert hash to hexadecimal string
+        let hashHex = hashData.map { String(format: "%02x", $0) }.joined()
+
+        // Iterate over each character in the address and apply checksum
+        var checksumAddress = "0x"
+        for (index, char) in cleanAddress.enumerated() {
+            let hashChar = hashHex[hashHex.index(hashHex.startIndex, offsetBy: index)]
+            if let hashValue = Int(String(hashChar), radix: 16), hashValue >= 8 {
+                checksumAddress.append(char.uppercased())
+            } else {
+                checksumAddress.append(char.lowercased())
+            }
+        }
+
+        return checksumAddress
     }
 }

--- a/Tests/EthTests/EthAddressTests.swift
+++ b/Tests/EthTests/EthAddressTests.swift
@@ -39,4 +39,9 @@ final class EthAddressTests: XCTestCase {
             XCTAssertEqual(error.localizedDescription, "The data couldn’t be read because it isn’t in the correct format.")
         }
     }
+
+    func testChecksumAddress() {
+        let address = EthAddress("0xdef1c0ded9bec7f1a1670819833240f027b25eff")
+        XCTAssertEqual(address.checksum, "0xDef1C0ded9bec7F1a1670819833240f027b25EfF", "Should be checksummed address")
+    }
 }


### PR DESCRIPTION
This adds Ethereum's checksum addressing, which is just to verify plausable addresses via capitalization.