### PR TITLE
Upgrade to swift 6

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "392478dc45265e22cfdcef9df252d7110b3ba1671f6740a4d8129518af4e8895",
+  "originHash" : "bd0ab141007bdb5d08b2cf99a644bcfb1b6059843fd04ada7eb94d1d6a2aee7a",
   "pins" : [
     {
       "identity" : "bigint",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/attaswift/BigInt.git",
       "state" : {
-        "revision" : "0ed110f7555c34ff468e72e1686e59721f2b0da6",
-        "version" : "5.3.0"
+        "revision" : "d013a2b66ee468aade6da1f26c6d55cb6cd2e9ad",
+        "version" : "5.5.2"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
-        "version" : "510.0.2"
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -8,7 +8,7 @@ let package = Package(
     platforms: [
         .macOS(.v10_15),
         .iOS(.v13),
-        .tvOS(.v11),
+        .tvOS(.v13),
         .visionOS(.v1),
     ],
     products: [
@@ -23,9 +23,9 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/attaswift/BigInt.git", from: "5.3.0"),
+        .package(url: "https://github.com/attaswift/BigInt.git", from: "5.5.1"),
         .package(url: "https://github.com/hayesgm/SwiftKeccak.git", branch: "98a9d4a037dd62283977d5e0ef7d11c5612ff813"),
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.2"),
+        .package(url: "https://github.com/apple/swift-syntax.git", from: "601.0.1"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0"),
     ],
     targets: [

--- a/Sources/Eth/ABI/Function.swift
+++ b/Sources/Eth/ABI/Function.swift
@@ -44,7 +44,7 @@ public extension ABI {
     /// > ABI.Function(name: "myError", inputs: [.uint8]).decodeInput(input: Hex("0x10ff10dd0000000000000000000000000000000000000000000000000000000000000016"))
     /// ABI.Value.tuple1(.uint8(22))
     /// ```
-    struct Function: Equatable, CustomStringConvertible {
+    struct Function: Equatable, CustomStringConvertible, Sendable {
         public let name: String
         public let inputs: [ABI.Schema]
         public let outputs: [ABI.Schema]

--- a/Sources/Eth/ABI/Schema.swift
+++ b/Sources/Eth/ABI/Schema.swift
@@ -19,7 +19,7 @@ public extension ABI {
      - mismatchedType: The types provided do not match the schema.
      - invalidResponse: The response is invalid.
      */
-    enum DecodeError: Error, Equatable {
+    enum DecodeError: Error, Equatable, Sendable {
         case insufficientData(Schema, Hex)
         case excessData(Schema, Hex)
         case nonEmptyDataFound(Schema, Hex)
@@ -38,7 +38,7 @@ public extension ABI {
     /**
      An enumeration of all possible Solidity ABI types (e.g. `.uint256` for "uint256", `.tuple([.array(.string)])` for "(string[])")
      */
-    enum Schema: Equatable, CustomStringConvertible {
+    enum Schema: Equatable, CustomStringConvertible, Sendable {
         // Unsigned Int
         case uint8
         case uint16

--- a/Sources/Eth/ABI/Value.swift
+++ b/Sources/Eth/ABI/Value.swift
@@ -43,7 +43,7 @@ public extension ABI {
      *   - Small integers (≤32 bits) are represented as `UInt` or `Int` values. Larger values are represented as `BigUInt` or `BigInt`.
      *   - Tuples are canonically represented for easy pattern-matching, e.g., `.tuple2(.uint256, .uint256)`. For tuples with more than 16 values, use `.tupleN([.uint256, ...])`.
      */
-    enum Value: Equatable, CustomStringConvertible {
+    enum Value: Equatable, CustomStringConvertible, Sendable {
         // Unsigned Int
         case uint8(UInt)
         case uint16(UInt)

--- a/Sources/Eth/EVM.swift
+++ b/Sources/Eth/EVM.swift
@@ -61,7 +61,7 @@ public enum EVM {
      - ok: The FFI succeeded and returned the given bytes
      - revert: The FFI reverted and returned the given error bytes
      */
-    public enum FFIResult: Error, Equatable {
+    public enum FFIResult: Error, Equatable, Sendable {
         case ok(Hex)
         case revert(Hex)
     }
@@ -78,7 +78,7 @@ public enum EVM {
     }
 
     /// Inputs to an EVM call. That is, the `calldata` and ETH `value`.
-    public struct CallInput {
+    public struct CallInput: Sendable {
         public let calldata: Hex
         public let value: BigUInt
 
@@ -110,9 +110,9 @@ public enum EVM {
     /// A structure to store the VM stack during execution of an EVM program.
     public typealias Stack = [EthWord]
 
-    public typealias FFIMap = [EthAddress: (Hex) async -> FFIResult]
+    public typealias FFIMap = [EthAddress: @Sendable (Hex) async -> FFIResult]
 
-    struct Context {
+    struct Context: Sendable {
         var pc: Int = 0
         var stack: Stack = []
         var memory: Data = .init()
@@ -252,7 +252,7 @@ public enum EVM {
     }
 
     /// A mapping of all known EVM operations.
-    public enum Operation: Equatable {
+    public enum Operation: Equatable, Sendable {
         case stop
         case add
         case sub

--- a/Sources/Eth/EthAddress.swift
+++ b/Sources/Eth/EthAddress.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftKeccak
 
 /// `EthAddress` represents a 20-byte Ethereum address
-public struct EthAddress: Codable, Equatable, Hashable, CustomStringConvertible, ExpressibleByStringLiteral {
+public struct EthAddress: Codable, Equatable, Hashable, CustomStringConvertible, ExpressibleByStringLiteral, Sendable {
     /// The 20-byte `Hex` struct representing the Ethereum address
     public let address: Hex
 

--- a/Sources/Eth/EthWord.swift
+++ b/Sources/Eth/EthWord.swift
@@ -2,7 +2,7 @@ import BigInt
 import Foundation
 
 /// A 256-bit (32-byte) word used in Ethereum operations.
-public struct EthWord: Codable, Equatable, Hashable, CustomStringConvertible, ExpressibleByStringLiteral {
+public struct EthWord: Codable, Equatable, Hashable, CustomStringConvertible, ExpressibleByStringLiteral, Sendable {
     public let hex: Hex
 
     /// Initializes an `EthWord` with a 32-byte `Hex` data.

--- a/Sources/Eth/Hex.swift
+++ b/Sources/Eth/Hex.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Hex is a light wrapper around `Data` to make it easily convertable to and from hex strings.
-public struct Hex: Codable, Equatable, Hashable, CustomStringConvertible, ExpressibleByStringLiteral {
+public struct Hex: Codable, Equatable, Hashable, CustomStringConvertible, ExpressibleByStringLiteral, Sendable {
     public let data: Data
 
     /// Represents an error parsing hex
@@ -52,7 +52,7 @@ public struct Hex: Codable, Equatable, Hashable, CustomStringConvertible, Expres
     }
 
     /// An empty `Hex` value
-    public static var empty = Hex(Data())
+    public static let empty = Hex(Data())
 
     /// A string representation of the `Hex` value.
     public var description: String {

--- a/Tests/EthTests/ComplianceTests.swift
+++ b/Tests/EthTests/ComplianceTests.swift
@@ -40,10 +40,18 @@ final class ComplianceTests: XCTestCase {
     func testRunComplianceTests() async throws {
         // Load all tests from `Tests/ComplianceJson/*.json` as a `ComplianceTest` struct
         let directoryPath = "./Tests/ComplianceJson/"
+        let complianceTests: [ComplianceTest] = loadComplianceTests(directoryPath: directoryPath)
+
+        for test in complianceTests {
+            let resp: Hex = try await EVM.runQuery(bytecode: test.bytecode, query: test.query)
+            XCTAssertEqual(resp, test.expResp, test.name)
+        }
+    }
+
+    private func loadComplianceTests(directoryPath: String) -> [ComplianceTest] {
         let fileManager = FileManager.default
         var complianceTests: [ComplianceTest] = []
 
-        // Get all JSON files in the directory
         if let enumerator = fileManager.enumerator(atPath: directoryPath) {
             for case let file as String in enumerator {
                 if file.hasSuffix(".json") {
@@ -56,10 +64,7 @@ final class ComplianceTests: XCTestCase {
                 }
             }
         }
-
-        for test in complianceTests {
-            let resp: Hex = try await EVM.runQuery(bytecode: test.bytecode, query: test.query)
-            XCTAssertEqual(resp, test.expResp, test.name)
-        }
+        
+        return complianceTests
     }
 }

--- a/Tests/EthTests/EVMTests.swift
+++ b/Tests/EthTests/EVMTests.swift
@@ -56,7 +56,7 @@ private func longFFI(args: Hex) -> EVM.FFIResult {
     }
 }
 
-struct EvmTest {
+struct EvmTest: Sendable {
     let name: String
     let code: EVM.Code
     let input: EVM.CallInput


### PR DESCRIPTION
This upgrades to Swift 6, exported types such as `EthAddress` and `Hex` are now `Sendable`. This also updates Geno to generate Sendable types which helps for consumers not having to use `@unsafe sendable`. Finally, it also bumps tvOS version as well as swift syntax and big int libraries