### PR TITLE
Re-Sync the EVM

### DIFF
--- a/Sources/Eth/Contract/IConsole.swift
+++ b/Sources/Eth/Contract/IConsole.swift
@@ -24,10 +24,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log(p0: EthAddress, p1: EthAddress, p2: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log(p0: EthAddress, p1: EthAddress, p2: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logFn.encoded(with: [.address(p0), .address(p1), .string(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logFn.decode(output: result)
 
             switch decoded {
@@ -47,10 +47,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__1(p0: Bool, p1: BigUInt, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__1(p0: Bool, p1: BigUInt, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__1Fn.encoded(with: [.bool(p0), .uint256(p1), .uint256(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__1Fn.decode(output: result)
 
             switch decoded {
@@ -70,10 +70,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__2(p0: EthAddress, p1: EthAddress, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__2(p0: EthAddress, p1: EthAddress, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__2Fn.encoded(with: [.address(p0), .address(p1), .address(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__2Fn.decode(output: result)
 
             switch decoded {
@@ -93,10 +93,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__3(p0: BigUInt, p1: EthAddress, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__3(p0: BigUInt, p1: EthAddress, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__3Fn.encoded(with: [.uint256(p0), .address(p1), .address(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__3Fn.decode(output: result)
 
             switch decoded {
@@ -116,10 +116,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__4(p0: String, p1: EthAddress, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__4(p0: String, p1: EthAddress, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__4Fn.encoded(with: [.string(p0), .address(p1), .bool(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__4Fn.decode(output: result)
 
             switch decoded {
@@ -139,10 +139,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__5(p0: BigUInt, p1: Bool, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__5(p0: BigUInt, p1: Bool, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__5Fn.encoded(with: [.uint256(p0), .bool(p1), .address(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__5Fn.decode(output: result)
 
             switch decoded {
@@ -162,10 +162,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__6(p0: Bool, p1: EthAddress, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__6(p0: Bool, p1: EthAddress, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__6Fn.encoded(with: [.bool(p0), .address(p1), .bool(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__6Fn.decode(output: result)
 
             switch decoded {
@@ -185,10 +185,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__7(p0: Bool, p1: BigUInt, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__7(p0: Bool, p1: BigUInt, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__7Fn.encoded(with: [.bool(p0), .uint256(p1), .address(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__7Fn.decode(output: result)
 
             switch decoded {
@@ -208,10 +208,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__8(p0: BigUInt, p1: EthAddress, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__8(p0: BigUInt, p1: EthAddress, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__8Fn.encoded(with: [.uint256(p0), .address(p1), .address(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__8Fn.decode(output: result)
 
             switch decoded {
@@ -231,10 +231,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__9(p0: EthAddress, p1: Bool, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__9(p0: EthAddress, p1: Bool, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__9Fn.encoded(with: [.address(p0), .bool(p1), .uint256(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__9Fn.decode(output: result)
 
             switch decoded {
@@ -254,10 +254,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__10(p0: Bool, p1: Bool, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__10(p0: Bool, p1: Bool, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__10Fn.encoded(with: [.bool(p0), .bool(p1), .uint256(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__10Fn.decode(output: result)
 
             switch decoded {
@@ -277,10 +277,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__11(p0: Bool, p1: EthAddress, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__11(p0: Bool, p1: EthAddress, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__11Fn.encoded(with: [.bool(p0), .address(p1), .address(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__11Fn.decode(output: result)
 
             switch decoded {
@@ -300,10 +300,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__12(p0: BigUInt, p1: EthAddress, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__12(p0: BigUInt, p1: EthAddress, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__12Fn.encoded(with: [.uint256(p0), .address(p1), .uint256(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__12Fn.decode(output: result)
 
             switch decoded {
@@ -323,10 +323,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__13(p0: String, p1: EthAddress, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__13(p0: String, p1: EthAddress, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__13Fn.encoded(with: [.string(p0), .address(p1), .uint256(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__13Fn.decode(output: result)
 
             switch decoded {
@@ -346,10 +346,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__14(p0: EthAddress, p1: String, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__14(p0: EthAddress, p1: String, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__14Fn.encoded(with: [.address(p0), .string(p1), .address(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__14Fn.decode(output: result)
 
             switch decoded {
@@ -369,10 +369,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__15(p0: EthAddress, p1: String, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__15(p0: EthAddress, p1: String, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__15Fn.encoded(with: [.address(p0), .string(p1), .address(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__15Fn.decode(output: result)
 
             switch decoded {
@@ -392,10 +392,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__16(p0: EthAddress, p1: EthAddress, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__16(p0: EthAddress, p1: EthAddress, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__16Fn.encoded(with: [.address(p0), .address(p1), .address(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__16Fn.decode(output: result)
 
             switch decoded {
@@ -415,10 +415,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__17(p0: EthAddress, p1: String, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__17(p0: EthAddress, p1: String, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__17Fn.encoded(with: [.address(p0), .string(p1), .uint256(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__17Fn.decode(output: result)
 
             switch decoded {
@@ -438,10 +438,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__18(p0: EthAddress, p1: BigUInt, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__18(p0: EthAddress, p1: BigUInt, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__18Fn.encoded(with: [.address(p0), .uint256(p1), .address(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__18Fn.decode(output: result)
 
             switch decoded {
@@ -461,10 +461,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__19(p0: String, p1: String, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__19(p0: String, p1: String, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__19Fn.encoded(with: [.string(p0), .string(p1), .uint256(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__19Fn.decode(output: result)
 
             switch decoded {
@@ -484,10 +484,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__20(p0: Bool, p1: Bool, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__20(p0: Bool, p1: Bool, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__20Fn.encoded(with: [.bool(p0), .bool(p1), .address(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__20Fn.decode(output: result)
 
             switch decoded {
@@ -507,10 +507,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__21(p0: Bool, p1: String, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__21(p0: Bool, p1: String, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__21Fn.encoded(with: [.bool(p0), .string(p1), .uint256(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__21Fn.decode(output: result)
 
             switch decoded {
@@ -530,10 +530,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__22(p0: Bool, p1: String, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__22(p0: Bool, p1: String, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__22Fn.encoded(with: [.bool(p0), .string(p1), .address(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__22Fn.decode(output: result)
 
             switch decoded {
@@ -553,10 +553,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__23(p0: Bool, p1: Bool, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__23(p0: Bool, p1: Bool, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__23Fn.encoded(with: [.bool(p0), .bool(p1), .uint256(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__23Fn.decode(output: result)
 
             switch decoded {
@@ -576,10 +576,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__24(p0: Bool, p1: EthAddress, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__24(p0: Bool, p1: EthAddress, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__24Fn.encoded(with: [.bool(p0), .address(p1), .uint256(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__24Fn.decode(output: result)
 
             switch decoded {
@@ -599,10 +599,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__25(p0: Bool, p1: BigUInt, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__25(p0: Bool, p1: BigUInt, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__25Fn.encoded(with: [.bool(p0), .uint256(p1), .address(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__25Fn.decode(output: result)
 
             switch decoded {
@@ -622,10 +622,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__26(p0: Bool, p1: String, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__26(p0: Bool, p1: String, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__26Fn.encoded(with: [.bool(p0), .string(p1), .uint256(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__26Fn.decode(output: result)
 
             switch decoded {
@@ -645,10 +645,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__27(p0: EthAddress, p1: String, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__27(p0: EthAddress, p1: String, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__27Fn.encoded(with: [.address(p0), .string(p1), .string(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__27Fn.decode(output: result)
 
             switch decoded {
@@ -668,10 +668,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__28(p0: BigUInt, p1: EthAddress, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__28(p0: BigUInt, p1: EthAddress, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__28Fn.encoded(with: [.uint256(p0), .address(p1), .uint256(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__28Fn.decode(output: result)
 
             switch decoded {
@@ -691,10 +691,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__29(p0: BigUInt, p1: BigUInt, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__29(p0: BigUInt, p1: BigUInt, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__29Fn.encoded(with: [.uint256(p0), .uint256(p1), .address(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__29Fn.decode(output: result)
 
             switch decoded {
@@ -714,10 +714,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__30(p0: Bool, p1: String, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__30(p0: Bool, p1: String, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__30Fn.encoded(with: [.bool(p0), .string(p1), .bool(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__30Fn.decode(output: result)
 
             switch decoded {
@@ -737,10 +737,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__31(p0: Bool, p1: String, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__31(p0: Bool, p1: String, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__31Fn.encoded(with: [.bool(p0), .string(p1), .string(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__31Fn.decode(output: result)
 
             switch decoded {
@@ -760,10 +760,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__32(p0: EthAddress, p1: EthAddress, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__32(p0: EthAddress, p1: EthAddress, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__32Fn.encoded(with: [.address(p0), .address(p1), .uint256(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__32Fn.decode(output: result)
 
             switch decoded {
@@ -783,10 +783,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__33(p0: Bool, p1: EthAddress, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__33(p0: Bool, p1: EthAddress, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__33Fn.encoded(with: [.bool(p0), .address(p1), .bool(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__33Fn.decode(output: result)
 
             switch decoded {
@@ -806,10 +806,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__34(p0: BigUInt, p1: BigUInt, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__34(p0: BigUInt, p1: BigUInt, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__34Fn.encoded(with: [.uint256(p0), .uint256(p1), .uint256(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__34Fn.decode(output: result)
 
             switch decoded {
@@ -829,10 +829,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__35(p0: EthAddress, p1: Bool, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__35(p0: EthAddress, p1: Bool, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__35Fn.encoded(with: [.address(p0), .bool(p1), .string(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__35Fn.decode(output: result)
 
             switch decoded {
@@ -852,10 +852,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__36(p0: Bool, p1: String, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__36(p0: Bool, p1: String, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__36Fn.encoded(with: [.bool(p0), .string(p1), .uint256(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__36Fn.decode(output: result)
 
             switch decoded {
@@ -875,10 +875,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__37(p0: Bool, p1: BigUInt, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__37(p0: Bool, p1: BigUInt, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__37Fn.encoded(with: [.bool(p0), .uint256(p1), .address(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__37Fn.decode(output: result)
 
             switch decoded {
@@ -898,10 +898,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__38(p0: Bool, p1: EthAddress, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__38(p0: Bool, p1: EthAddress, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__38Fn.encoded(with: [.bool(p0), .address(p1), .bool(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__38Fn.decode(output: result)
 
             switch decoded {
@@ -921,10 +921,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__39(p0: String, p1: BigUInt, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__39(p0: String, p1: BigUInt, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__39Fn.encoded(with: [.string(p0), .uint256(p1), .address(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__39Fn.decode(output: result)
 
             switch decoded {
@@ -944,10 +944,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__40(p0: BigUInt, p1: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__40(p0: BigUInt, p1: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__40Fn.encoded(with: [.uint256(p0), .bool(p1)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__40Fn.decode(output: result)
 
             switch decoded {
@@ -967,10 +967,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__41(p0: Bool, p1: EthAddress, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__41(p0: Bool, p1: EthAddress, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__41Fn.encoded(with: [.bool(p0), .address(p1), .address(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__41Fn.decode(output: result)
 
             switch decoded {
@@ -990,10 +990,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__42(p0: EthAddress, p1: BigUInt, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__42(p0: EthAddress, p1: BigUInt, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__42Fn.encoded(with: [.address(p0), .uint256(p1), .address(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__42Fn.decode(output: result)
 
             switch decoded {
@@ -1013,10 +1013,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__43(p0: EthAddress, p1: String, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__43(p0: EthAddress, p1: String, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__43Fn.encoded(with: [.address(p0), .string(p1), .uint256(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__43Fn.decode(output: result)
 
             switch decoded {
@@ -1036,10 +1036,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__44(p0: Bool, p1: String, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__44(p0: Bool, p1: String, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__44Fn.encoded(with: [.bool(p0), .string(p1), .string(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__44Fn.decode(output: result)
 
             switch decoded {
@@ -1059,10 +1059,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__45(p0: BigUInt, p1: Bool, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__45(p0: BigUInt, p1: Bool, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__45Fn.encoded(with: [.uint256(p0), .bool(p1), .uint256(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__45Fn.decode(output: result)
 
             switch decoded {
@@ -1082,10 +1082,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__46(p0: EthAddress, p1: String, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__46(p0: EthAddress, p1: String, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__46Fn.encoded(with: [.address(p0), .string(p1), .bool(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__46Fn.decode(output: result)
 
             switch decoded {
@@ -1105,10 +1105,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__47(p0: BigUInt, p1: Bool, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__47(p0: BigUInt, p1: Bool, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__47Fn.encoded(with: [.uint256(p0), .bool(p1), .bool(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__47Fn.decode(output: result)
 
             switch decoded {
@@ -1128,10 +1128,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__48(p0: EthAddress, p1: BigUInt, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__48(p0: EthAddress, p1: BigUInt, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__48Fn.encoded(with: [.address(p0), .uint256(p1), .uint256(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__48Fn.decode(output: result)
 
             switch decoded {
@@ -1151,10 +1151,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__49(p0: EthAddress, p1: Bool, p2: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__49(p0: EthAddress, p1: Bool, p2: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__49Fn.encoded(with: [.address(p0), .bool(p1), .string(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__49Fn.decode(output: result)
 
             switch decoded {
@@ -1174,10 +1174,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__50(p0: BigUInt, p1: String, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__50(p0: BigUInt, p1: String, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__50Fn.encoded(with: [.uint256(p0), .string(p1), .string(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__50Fn.decode(output: result)
 
             switch decoded {
@@ -1197,10 +1197,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__51(p0: EthAddress, p1: EthAddress, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__51(p0: EthAddress, p1: EthAddress, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__51Fn.encoded(with: [.address(p0), .address(p1), .string(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__51Fn.decode(output: result)
 
             switch decoded {
@@ -1220,10 +1220,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__52(p0: String, p1: EthAddress, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__52(p0: String, p1: EthAddress, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__52Fn.encoded(with: [.string(p0), .address(p1), .bool(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__52Fn.decode(output: result)
 
             switch decoded {
@@ -1243,10 +1243,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__53(p0: EthAddress, p1: BigUInt, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__53(p0: EthAddress, p1: BigUInt, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__53Fn.encoded(with: [.address(p0), .uint256(p1), .bool(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__53Fn.decode(output: result)
 
             switch decoded {
@@ -1266,10 +1266,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__54(p0: String, p1: EthAddress, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__54(p0: String, p1: EthAddress, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__54Fn.encoded(with: [.string(p0), .address(p1), .string(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__54Fn.decode(output: result)
 
             switch decoded {
@@ -1289,10 +1289,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__55(p0: BigUInt, p1: EthAddress, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__55(p0: BigUInt, p1: EthAddress, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__55Fn.encoded(with: [.uint256(p0), .address(p1), .address(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__55Fn.decode(output: result)
 
             switch decoded {
@@ -1312,10 +1312,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__56(p0: String, p1: Bool, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__56(p0: String, p1: Bool, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__56Fn.encoded(with: [.string(p0), .bool(p1), .string(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__56Fn.decode(output: result)
 
             switch decoded {
@@ -1335,10 +1335,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__57(p0: Bool, p1: Bool, p2: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__57(p0: Bool, p1: Bool, p2: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__57Fn.encoded(with: [.bool(p0), .bool(p1), .string(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__57Fn.decode(output: result)
 
             switch decoded {
@@ -1358,10 +1358,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__58(p0: Bool, p1: BigUInt, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__58(p0: Bool, p1: BigUInt, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__58Fn.encoded(with: [.bool(p0), .uint256(p1), .address(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__58Fn.decode(output: result)
 
             switch decoded {
@@ -1381,10 +1381,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__59(p0: BigUInt, p1: BigUInt, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__59(p0: BigUInt, p1: BigUInt, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__59Fn.encoded(with: [.uint256(p0), .uint256(p1), .string(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__59Fn.decode(output: result)
 
             switch decoded {
@@ -1404,10 +1404,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__60(p0: Bool, p1: String, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__60(p0: Bool, p1: String, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__60Fn.encoded(with: [.bool(p0), .string(p1), .uint256(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__60Fn.decode(output: result)
 
             switch decoded {
@@ -1427,10 +1427,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__61(p0: Bool, p1: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__61(p0: Bool, p1: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__61Fn.encoded(with: [.bool(p0), .bool(p1)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__61Fn.decode(output: result)
 
             switch decoded {
@@ -1450,10 +1450,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__62(p0: Bool, p1: Bool, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__62(p0: Bool, p1: Bool, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__62Fn.encoded(with: [.bool(p0), .bool(p1), .bool(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__62Fn.decode(output: result)
 
             switch decoded {
@@ -1473,10 +1473,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__63(p0: Bool, p1: String, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__63(p0: Bool, p1: String, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__63Fn.encoded(with: [.bool(p0), .string(p1), .address(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__63Fn.decode(output: result)
 
             switch decoded {
@@ -1496,10 +1496,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__64(p0: String, p1: String, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__64(p0: String, p1: String, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__64Fn.encoded(with: [.string(p0), .string(p1), .string(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__64Fn.decode(output: result)
 
             switch decoded {
@@ -1519,10 +1519,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__65(p0: BigUInt, p1: Bool, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__65(p0: BigUInt, p1: Bool, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__65Fn.encoded(with: [.uint256(p0), .bool(p1), .string(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__65Fn.decode(output: result)
 
             switch decoded {
@@ -1542,10 +1542,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__66(p0: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__66(p0: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__66Fn.encoded(with: [.address(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__66Fn.decode(output: result)
 
             switch decoded {
@@ -1565,10 +1565,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__67(p0: EthAddress, p1: EthAddress, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__67(p0: EthAddress, p1: EthAddress, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__67Fn.encoded(with: [.address(p0), .address(p1), .bool(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__67Fn.decode(output: result)
 
             switch decoded {
@@ -1588,10 +1588,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__68(p0: String, p1: String, p2: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__68(p0: String, p1: String, p2: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__68Fn.encoded(with: [.string(p0), .string(p1), .string(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__68Fn.decode(output: result)
 
             switch decoded {
@@ -1611,10 +1611,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__69(p0: BigInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__69(p0: BigInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__69Fn.encoded(with: [.int256(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__69Fn.decode(output: result)
 
             switch decoded {
@@ -1634,10 +1634,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__70(p0: String, p1: Bool, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__70(p0: String, p1: Bool, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__70Fn.encoded(with: [.string(p0), .bool(p1), .address(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__70Fn.decode(output: result)
 
             switch decoded {
@@ -1657,10 +1657,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__71(p0: EthAddress, p1: Bool, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__71(p0: EthAddress, p1: Bool, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__71Fn.encoded(with: [.address(p0), .bool(p1), .address(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__71Fn.decode(output: result)
 
             switch decoded {
@@ -1680,10 +1680,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__72(p0: String, p1: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__72(p0: String, p1: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__72Fn.encoded(with: [.string(p0), .address(p1)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__72Fn.decode(output: result)
 
             switch decoded {
@@ -1703,10 +1703,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__73(p0: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__73(p0: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__73Fn.encoded(with: [.bool(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__73Fn.decode(output: result)
 
             switch decoded {
@@ -1726,10 +1726,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__74(p0: String, p1: Bool, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__74(p0: String, p1: Bool, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__74Fn.encoded(with: [.string(p0), .bool(p1), .address(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__74Fn.decode(output: result)
 
             switch decoded {
@@ -1749,10 +1749,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__75(p0: EthAddress, p1: BigUInt, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__75(p0: EthAddress, p1: BigUInt, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__75Fn.encoded(with: [.address(p0), .uint256(p1), .uint256(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__75Fn.decode(output: result)
 
             switch decoded {
@@ -1772,10 +1772,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__76(p0: BigUInt, p1: Bool, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__76(p0: BigUInt, p1: Bool, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__76Fn.encoded(with: [.uint256(p0), .bool(p1), .address(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__76Fn.decode(output: result)
 
             switch decoded {
@@ -1795,10 +1795,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__77(p0: String, p1: BigUInt, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__77(p0: String, p1: BigUInt, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__77Fn.encoded(with: [.string(p0), .uint256(p1), .bool(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__77Fn.decode(output: result)
 
             switch decoded {
@@ -1818,10 +1818,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__78(p0: EthAddress, p1: String, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__78(p0: EthAddress, p1: String, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__78Fn.encoded(with: [.address(p0), .string(p1), .string(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__78Fn.decode(output: result)
 
             switch decoded {
@@ -1841,10 +1841,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__79(p0: Bool, p1: BigUInt, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__79(p0: Bool, p1: BigUInt, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__79Fn.encoded(with: [.bool(p0), .uint256(p1), .uint256(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__79Fn.decode(output: result)
 
             switch decoded {
@@ -1864,10 +1864,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__80(p0: Bool, p1: BigUInt, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__80(p0: Bool, p1: BigUInt, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__80Fn.encoded(with: [.bool(p0), .uint256(p1), .uint256(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__80Fn.decode(output: result)
 
             switch decoded {
@@ -1887,10 +1887,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__81(p0: BigUInt, p1: String, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__81(p0: BigUInt, p1: String, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__81Fn.encoded(with: [.uint256(p0), .string(p1), .uint256(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__81Fn.decode(output: result)
 
             switch decoded {
@@ -1910,10 +1910,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__82(p0: EthAddress, p1: Bool, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__82(p0: EthAddress, p1: Bool, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__82Fn.encoded(with: [.address(p0), .bool(p1), .uint256(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__82Fn.decode(output: result)
 
             switch decoded {
@@ -1933,10 +1933,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__83(p0: EthAddress, p1: EthAddress, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__83(p0: EthAddress, p1: EthAddress, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__83Fn.encoded(with: [.address(p0), .address(p1), .bool(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__83Fn.decode(output: result)
 
             switch decoded {
@@ -1956,10 +1956,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__84(p0: Bool, p1: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__84(p0: Bool, p1: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__84Fn.encoded(with: [.bool(p0), .uint256(p1)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__84Fn.decode(output: result)
 
             switch decoded {
@@ -1979,10 +1979,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__85(p0: BigUInt, p1: String, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__85(p0: BigUInt, p1: String, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__85Fn.encoded(with: [.uint256(p0), .string(p1), .uint256(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__85Fn.decode(output: result)
 
             switch decoded {
@@ -2002,10 +2002,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__86(p0: Bool, p1: Bool, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__86(p0: Bool, p1: Bool, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__86Fn.encoded(with: [.bool(p0), .bool(p1), .bool(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__86Fn.decode(output: result)
 
             switch decoded {
@@ -2025,10 +2025,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__87(p0: EthAddress, p1: BigUInt, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__87(p0: EthAddress, p1: BigUInt, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__87Fn.encoded(with: [.address(p0), .uint256(p1), .bool(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__87Fn.decode(output: result)
 
             switch decoded {
@@ -2048,10 +2048,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__88(p0: String, p1: BigInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__88(p0: String, p1: BigInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__88Fn.encoded(with: [.string(p0), .int256(p1)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__88Fn.decode(output: result)
 
             switch decoded {
@@ -2071,10 +2071,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__89(p0: BigUInt, p1: EthAddress, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__89(p0: BigUInt, p1: EthAddress, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__89Fn.encoded(with: [.uint256(p0), .address(p1), .string(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__89Fn.decode(output: result)
 
             switch decoded {
@@ -2094,10 +2094,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__90(p0: String, p1: EthAddress, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__90(p0: String, p1: EthAddress, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__90Fn.encoded(with: [.string(p0), .address(p1), .bool(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__90Fn.decode(output: result)
 
             switch decoded {
@@ -2117,10 +2117,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__91(p0: String, p1: Bool, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__91(p0: String, p1: Bool, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__91Fn.encoded(with: [.string(p0), .bool(p1), .string(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__91Fn.decode(output: result)
 
             switch decoded {
@@ -2140,10 +2140,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__92(p0: String, p1: String, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__92(p0: String, p1: String, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__92Fn.encoded(with: [.string(p0), .string(p1), .bool(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__92Fn.decode(output: result)
 
             switch decoded {
@@ -2163,10 +2163,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__93(p0: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__93(p0: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__93Fn.encoded(with: [.string(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__93Fn.decode(output: result)
 
             switch decoded {
@@ -2186,10 +2186,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__94(p0: BigUInt, p1: BigUInt, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__94(p0: BigUInt, p1: BigUInt, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__94Fn.encoded(with: [.uint256(p0), .uint256(p1), .string(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__94Fn.decode(output: result)
 
             switch decoded {
@@ -2209,10 +2209,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__95(p0: String, p1: String, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__95(p0: String, p1: String, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__95Fn.encoded(with: [.string(p0), .string(p1), .address(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__95Fn.decode(output: result)
 
             switch decoded {
@@ -2232,10 +2232,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__96(p0: EthAddress, p1: String, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__96(p0: EthAddress, p1: String, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__96Fn.encoded(with: [.address(p0), .string(p1), .uint256(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__96Fn.decode(output: result)
 
             switch decoded {
@@ -2255,10 +2255,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__97(p0: BigUInt, p1: Bool, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__97(p0: BigUInt, p1: Bool, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__97Fn.encoded(with: [.uint256(p0), .bool(p1), .address(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__97Fn.decode(output: result)
 
             switch decoded {
@@ -2278,10 +2278,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__98(p0: EthAddress, p1: String, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__98(p0: EthAddress, p1: String, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__98Fn.encoded(with: [.address(p0), .string(p1), .address(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__98Fn.decode(output: result)
 
             switch decoded {
@@ -2301,10 +2301,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__99(p0: Bool, p1: EthAddress, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__99(p0: Bool, p1: EthAddress, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__99Fn.encoded(with: [.bool(p0), .address(p1), .address(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__99Fn.decode(output: result)
 
             switch decoded {
@@ -2324,10 +2324,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__100(p0: BigUInt, p1: EthAddress, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__100(p0: BigUInt, p1: EthAddress, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__100Fn.encoded(with: [.uint256(p0), .address(p1), .string(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__100Fn.decode(output: result)
 
             switch decoded {
@@ -2347,10 +2347,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__101(p0: EthAddress, p1: Bool, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__101(p0: EthAddress, p1: Bool, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__101Fn.encoded(with: [.address(p0), .bool(p1), .string(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__101Fn.decode(output: result)
 
             switch decoded {
@@ -2370,10 +2370,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__102(p0: BigUInt, p1: BigUInt, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__102(p0: BigUInt, p1: BigUInt, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__102Fn.encoded(with: [.uint256(p0), .uint256(p1), .bool(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__102Fn.decode(output: result)
 
             switch decoded {
@@ -2393,10 +2393,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__103(p0: EthAddress, p1: BigUInt, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__103(p0: EthAddress, p1: BigUInt, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__103Fn.encoded(with: [.address(p0), .uint256(p1), .address(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__103Fn.decode(output: result)
 
             switch decoded {
@@ -2416,10 +2416,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__104(p0: Bool, p1: String, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__104(p0: Bool, p1: String, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__104Fn.encoded(with: [.bool(p0), .string(p1), .bool(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__104Fn.decode(output: result)
 
             switch decoded {
@@ -2439,10 +2439,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__105(p0: EthAddress, p1: BigUInt, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__105(p0: EthAddress, p1: BigUInt, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__105Fn.encoded(with: [.address(p0), .uint256(p1), .uint256(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__105Fn.decode(output: result)
 
             switch decoded {
@@ -2462,10 +2462,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__106(p0: Bool, p1: EthAddress, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__106(p0: Bool, p1: EthAddress, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__106Fn.encoded(with: [.bool(p0), .address(p1), .bool(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__106Fn.decode(output: result)
 
             switch decoded {
@@ -2485,10 +2485,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__107(p0: String, p1: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__107(p0: String, p1: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__107Fn.encoded(with: [.string(p0), .string(p1)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__107Fn.decode(output: result)
 
             switch decoded {
@@ -2508,10 +2508,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__108(p0: Bool, p1: Bool, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__108(p0: Bool, p1: Bool, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__108Fn.encoded(with: [.bool(p0), .bool(p1), .address(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__108Fn.decode(output: result)
 
             switch decoded {
@@ -2531,10 +2531,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__109(p0: BigUInt, p1: String, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__109(p0: BigUInt, p1: String, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__109Fn.encoded(with: [.uint256(p0), .string(p1), .bool(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__109Fn.decode(output: result)
 
             switch decoded {
@@ -2554,10 +2554,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__110(p0: String, p1: BigUInt, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__110(p0: String, p1: BigUInt, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__110Fn.encoded(with: [.string(p0), .uint256(p1), .address(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__110Fn.decode(output: result)
 
             switch decoded {
@@ -2577,10 +2577,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__111(p0: Bool, p1: Bool, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__111(p0: Bool, p1: Bool, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__111Fn.encoded(with: [.bool(p0), .bool(p1), .bool(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__111Fn.decode(output: result)
 
             switch decoded {
@@ -2600,10 +2600,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__112(p0: EthAddress, p1: Bool, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__112(p0: EthAddress, p1: Bool, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__112Fn.encoded(with: [.address(p0), .bool(p1), .string(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__112Fn.decode(output: result)
 
             switch decoded {
@@ -2623,10 +2623,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__113(p0: EthAddress, p1: String, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__113(p0: EthAddress, p1: String, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__113Fn.encoded(with: [.address(p0), .string(p1), .bool(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__113Fn.decode(output: result)
 
             switch decoded {
@@ -2646,10 +2646,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__114(withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__114(withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__114Fn.encoded(with: [])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__114Fn.decode(output: result)
 
             switch decoded {
@@ -2669,10 +2669,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__115(p0: Bool, p1: EthAddress, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__115(p0: Bool, p1: EthAddress, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__115Fn.encoded(with: [.bool(p0), .address(p1), .uint256(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__115Fn.decode(output: result)
 
             switch decoded {
@@ -2692,10 +2692,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__116(p0: Bool, p1: String, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__116(p0: Bool, p1: String, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__116Fn.encoded(with: [.bool(p0), .string(p1), .bool(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__116Fn.decode(output: result)
 
             switch decoded {
@@ -2715,10 +2715,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__117(p0: Bool, p1: Bool, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__117(p0: Bool, p1: Bool, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__117Fn.encoded(with: [.bool(p0), .bool(p1), .uint256(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__117Fn.decode(output: result)
 
             switch decoded {
@@ -2738,10 +2738,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__118(p0: BigUInt, p1: BigUInt, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__118(p0: BigUInt, p1: BigUInt, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__118Fn.encoded(with: [.uint256(p0), .uint256(p1), .address(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__118Fn.decode(output: result)
 
             switch decoded {
@@ -2761,10 +2761,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__119(p0: String, p1: String, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__119(p0: String, p1: String, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__119Fn.encoded(with: [.string(p0), .string(p1), .uint256(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__119Fn.decode(output: result)
 
             switch decoded {
@@ -2784,10 +2784,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__120(p0: String, p1: BigUInt, p2: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__120(p0: String, p1: BigUInt, p2: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__120Fn.encoded(with: [.string(p0), .uint256(p1), .string(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__120Fn.decode(output: result)
 
             switch decoded {
@@ -2807,10 +2807,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__121(p0: BigUInt, p1: BigUInt, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__121(p0: BigUInt, p1: BigUInt, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__121Fn.encoded(with: [.uint256(p0), .uint256(p1), .uint256(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__121Fn.decode(output: result)
 
             switch decoded {
@@ -2830,10 +2830,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__122(p0: String, p1: EthAddress, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__122(p0: String, p1: EthAddress, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__122Fn.encoded(with: [.string(p0), .address(p1), .uint256(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__122Fn.decode(output: result)
 
             switch decoded {
@@ -2853,10 +2853,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__123(p0: BigUInt, p1: EthAddress, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__123(p0: BigUInt, p1: EthAddress, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__123Fn.encoded(with: [.uint256(p0), .address(p1), .uint256(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__123Fn.decode(output: result)
 
             switch decoded {
@@ -2876,10 +2876,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__124(p0: String, p1: BigUInt, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__124(p0: String, p1: BigUInt, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__124Fn.encoded(with: [.string(p0), .uint256(p1), .string(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__124Fn.decode(output: result)
 
             switch decoded {
@@ -2899,10 +2899,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__125(p0: BigUInt, p1: EthAddress, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__125(p0: BigUInt, p1: EthAddress, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__125Fn.encoded(with: [.uint256(p0), .address(p1), .bool(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__125Fn.decode(output: result)
 
             switch decoded {
@@ -2922,10 +2922,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__126(p0: EthAddress, p1: BigUInt, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__126(p0: EthAddress, p1: BigUInt, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__126Fn.encoded(with: [.address(p0), .uint256(p1), .string(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__126Fn.decode(output: result)
 
             switch decoded {
@@ -2945,10 +2945,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__127(p0: BigUInt, p1: BigUInt, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__127(p0: BigUInt, p1: BigUInt, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__127Fn.encoded(with: [.uint256(p0), .uint256(p1), .address(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__127Fn.decode(output: result)
 
             switch decoded {
@@ -2968,10 +2968,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__128(p0: String, p1: String, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__128(p0: String, p1: String, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__128Fn.encoded(with: [.string(p0), .string(p1), .address(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__128Fn.decode(output: result)
 
             switch decoded {
@@ -2991,10 +2991,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__129(p0: EthAddress, p1: String, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__129(p0: EthAddress, p1: String, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__129Fn.encoded(with: [.address(p0), .string(p1), .string(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__129Fn.decode(output: result)
 
             switch decoded {
@@ -3014,10 +3014,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__130(p0: String, p1: Bool, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__130(p0: String, p1: Bool, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__130Fn.encoded(with: [.string(p0), .bool(p1), .address(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__130Fn.decode(output: result)
 
             switch decoded {
@@ -3037,10 +3037,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__131(p0: String, p1: String, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__131(p0: String, p1: String, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__131Fn.encoded(with: [.string(p0), .string(p1), .uint256(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__131Fn.decode(output: result)
 
             switch decoded {
@@ -3060,10 +3060,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__132(p0: BigUInt, p1: BigUInt, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__132(p0: BigUInt, p1: BigUInt, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__132Fn.encoded(with: [.uint256(p0), .uint256(p1), .string(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__132Fn.decode(output: result)
 
             switch decoded {
@@ -3083,10 +3083,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__133(p0: String, p1: String, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__133(p0: String, p1: String, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__133Fn.encoded(with: [.string(p0), .string(p1), .bool(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__133Fn.decode(output: result)
 
             switch decoded {
@@ -3106,10 +3106,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__134(p0: String, p1: BigUInt, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__134(p0: String, p1: BigUInt, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__134Fn.encoded(with: [.string(p0), .uint256(p1), .address(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__134Fn.decode(output: result)
 
             switch decoded {
@@ -3129,10 +3129,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__135(p0: String, p1: EthAddress, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__135(p0: String, p1: EthAddress, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__135Fn.encoded(with: [.string(p0), .address(p1), .string(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__135Fn.decode(output: result)
 
             switch decoded {
@@ -3152,10 +3152,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__136(p0: EthAddress, p1: String, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__136(p0: EthAddress, p1: String, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__136Fn.encoded(with: [.address(p0), .string(p1), .bool(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__136Fn.decode(output: result)
 
             switch decoded {
@@ -3175,10 +3175,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__137(p0: BigUInt, p1: EthAddress, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__137(p0: BigUInt, p1: EthAddress, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__137Fn.encoded(with: [.uint256(p0), .address(p1), .uint256(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__137Fn.decode(output: result)
 
             switch decoded {
@@ -3198,10 +3198,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__138(p0: Bool, p1: EthAddress, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__138(p0: Bool, p1: EthAddress, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__138Fn.encoded(with: [.bool(p0), .address(p1), .uint256(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__138Fn.decode(output: result)
 
             switch decoded {
@@ -3221,10 +3221,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__139(p0: BigUInt, p1: String, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__139(p0: BigUInt, p1: String, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__139Fn.encoded(with: [.uint256(p0), .string(p1), .address(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__139Fn.decode(output: result)
 
             switch decoded {
@@ -3244,10 +3244,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__140(p0: Bool, p1: Bool, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__140(p0: Bool, p1: Bool, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__140Fn.encoded(with: [.bool(p0), .bool(p1), .uint256(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__140Fn.decode(output: result)
 
             switch decoded {
@@ -3267,10 +3267,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__141(p0: EthAddress, p1: String, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__141(p0: EthAddress, p1: String, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__141Fn.encoded(with: [.address(p0), .string(p1), .uint256(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__141Fn.decode(output: result)
 
             switch decoded {
@@ -3290,10 +3290,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__142(p0: BigUInt, p1: EthAddress, p2: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__142(p0: BigUInt, p1: EthAddress, p2: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__142Fn.encoded(with: [.uint256(p0), .address(p1), .string(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__142Fn.decode(output: result)
 
             switch decoded {
@@ -3313,10 +3313,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__143(p0: String, p1: EthAddress, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__143(p0: String, p1: EthAddress, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__143Fn.encoded(with: [.string(p0), .address(p1), .uint256(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__143Fn.decode(output: result)
 
             switch decoded {
@@ -3336,10 +3336,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__144(p0: BigUInt, p1: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__144(p0: BigUInt, p1: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__144Fn.encoded(with: [.uint256(p0), .string(p1)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__144Fn.decode(output: result)
 
             switch decoded {
@@ -3359,10 +3359,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__145(p0: String, p1: Bool, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__145(p0: String, p1: Bool, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__145Fn.encoded(with: [.string(p0), .bool(p1), .uint256(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__145Fn.decode(output: result)
 
             switch decoded {
@@ -3382,10 +3382,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__146(p0: EthAddress, p1: Bool, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__146(p0: EthAddress, p1: Bool, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__146Fn.encoded(with: [.address(p0), .bool(p1), .address(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__146Fn.decode(output: result)
 
             switch decoded {
@@ -3405,10 +3405,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__147(p0: EthAddress, p1: EthAddress, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__147(p0: EthAddress, p1: EthAddress, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__147Fn.encoded(with: [.address(p0), .address(p1), .address(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__147Fn.decode(output: result)
 
             switch decoded {
@@ -3428,10 +3428,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__148(p0: EthAddress, p1: BigUInt, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__148(p0: EthAddress, p1: BigUInt, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__148Fn.encoded(with: [.address(p0), .uint256(p1), .uint256(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__148Fn.decode(output: result)
 
             switch decoded {
@@ -3451,10 +3451,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__149(p0: EthAddress, p1: BigUInt, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__149(p0: EthAddress, p1: BigUInt, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__149Fn.encoded(with: [.address(p0), .uint256(p1), .bool(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__149Fn.decode(output: result)
 
             switch decoded {
@@ -3474,10 +3474,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__150(p0: EthAddress, p1: String, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__150(p0: EthAddress, p1: String, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__150Fn.encoded(with: [.address(p0), .string(p1), .uint256(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__150Fn.decode(output: result)
 
             switch decoded {
@@ -3497,10 +3497,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__151(p0: BigUInt, p1: Bool, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__151(p0: BigUInt, p1: Bool, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__151Fn.encoded(with: [.uint256(p0), .bool(p1), .string(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__151Fn.decode(output: result)
 
             switch decoded {
@@ -3520,10 +3520,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__152(p0: BigUInt, p1: String, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__152(p0: BigUInt, p1: String, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__152Fn.encoded(with: [.uint256(p0), .string(p1), .uint256(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__152Fn.decode(output: result)
 
             switch decoded {
@@ -3543,10 +3543,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__153(p0: BigUInt, p1: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__153(p0: BigUInt, p1: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__153Fn.encoded(with: [.uint256(p0), .address(p1)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__153Fn.decode(output: result)
 
             switch decoded {
@@ -3566,10 +3566,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__154(p0: BigUInt, p1: Bool, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__154(p0: BigUInt, p1: Bool, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__154Fn.encoded(with: [.uint256(p0), .bool(p1), .bool(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__154Fn.decode(output: result)
 
             switch decoded {
@@ -3589,10 +3589,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__155(p0: Bool, p1: BigUInt, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__155(p0: Bool, p1: BigUInt, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__155Fn.encoded(with: [.bool(p0), .uint256(p1), .string(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__155Fn.decode(output: result)
 
             switch decoded {
@@ -3612,10 +3612,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__156(p0: Bool, p1: EthAddress, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__156(p0: Bool, p1: EthAddress, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__156Fn.encoded(with: [.bool(p0), .address(p1), .bool(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__156Fn.decode(output: result)
 
             switch decoded {
@@ -3635,10 +3635,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__157(p0: Bool, p1: String, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__157(p0: Bool, p1: String, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__157Fn.encoded(with: [.bool(p0), .string(p1), .uint256(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__157Fn.decode(output: result)
 
             switch decoded {
@@ -3658,10 +3658,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__158(p0: BigUInt, p1: BigUInt, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__158(p0: BigUInt, p1: BigUInt, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__158Fn.encoded(with: [.uint256(p0), .uint256(p1), .address(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__158Fn.decode(output: result)
 
             switch decoded {
@@ -3681,10 +3681,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__159(p0: Bool, p1: Bool, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__159(p0: Bool, p1: Bool, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__159Fn.encoded(with: [.bool(p0), .bool(p1), .string(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__159Fn.decode(output: result)
 
             switch decoded {
@@ -3704,10 +3704,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__160(p0: String, p1: String, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__160(p0: String, p1: String, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__160Fn.encoded(with: [.string(p0), .string(p1), .string(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__160Fn.decode(output: result)
 
             switch decoded {
@@ -3727,10 +3727,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__161(p0: Bool, p1: Bool, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__161(p0: Bool, p1: Bool, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__161Fn.encoded(with: [.bool(p0), .bool(p1), .bool(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__161Fn.decode(output: result)
 
             switch decoded {
@@ -3750,10 +3750,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__162(p0: Bool, p1: String, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__162(p0: Bool, p1: String, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__162Fn.encoded(with: [.bool(p0), .string(p1), .address(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__162Fn.decode(output: result)
 
             switch decoded {
@@ -3773,10 +3773,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__163(p0: EthAddress, p1: EthAddress, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__163(p0: EthAddress, p1: EthAddress, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__163Fn.encoded(with: [.address(p0), .address(p1), .string(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__163Fn.decode(output: result)
 
             switch decoded {
@@ -3796,10 +3796,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__164(p0: Bool, p1: EthAddress, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__164(p0: Bool, p1: EthAddress, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__164Fn.encoded(with: [.bool(p0), .address(p1), .string(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__164Fn.decode(output: result)
 
             switch decoded {
@@ -3819,10 +3819,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__165(p0: String, p1: Bool, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__165(p0: String, p1: Bool, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__165Fn.encoded(with: [.string(p0), .bool(p1), .bool(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__165Fn.decode(output: result)
 
             switch decoded {
@@ -3842,10 +3842,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__166(p0: BigUInt, p1: BigUInt, p2: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__166(p0: BigUInt, p1: BigUInt, p2: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__166Fn.encoded(with: [.uint256(p0), .uint256(p1), .string(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__166Fn.decode(output: result)
 
             switch decoded {
@@ -3865,10 +3865,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__167(p0: BigUInt, p1: EthAddress, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__167(p0: BigUInt, p1: EthAddress, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__167Fn.encoded(with: [.uint256(p0), .address(p1), .address(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__167Fn.decode(output: result)
 
             switch decoded {
@@ -3888,10 +3888,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__168(p0: String, p1: Bool, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__168(p0: String, p1: Bool, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__168Fn.encoded(with: [.string(p0), .bool(p1), .uint256(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__168Fn.decode(output: result)
 
             switch decoded {
@@ -3911,10 +3911,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__169(p0: BigUInt, p1: Bool, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__169(p0: BigUInt, p1: Bool, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__169Fn.encoded(with: [.uint256(p0), .bool(p1), .bool(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__169Fn.decode(output: result)
 
             switch decoded {
@@ -3934,10 +3934,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__170(p0: EthAddress, p1: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__170(p0: EthAddress, p1: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__170Fn.encoded(with: [.address(p0), .string(p1)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__170Fn.decode(output: result)
 
             switch decoded {
@@ -3957,10 +3957,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__171(p0: EthAddress, p1: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__171(p0: EthAddress, p1: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__171Fn.encoded(with: [.address(p0), .bool(p1)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__171Fn.decode(output: result)
 
             switch decoded {
@@ -3980,10 +3980,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__172(p0: String, p1: BigUInt, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__172(p0: String, p1: BigUInt, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__172Fn.encoded(with: [.string(p0), .uint256(p1), .uint256(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__172Fn.decode(output: result)
 
             switch decoded {
@@ -4003,10 +4003,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__173(p0: String, p1: EthAddress, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__173(p0: String, p1: EthAddress, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__173Fn.encoded(with: [.string(p0), .address(p1), .bool(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__173Fn.decode(output: result)
 
             switch decoded {
@@ -4026,10 +4026,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__174(p0: BigUInt, p1: BigUInt, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__174(p0: BigUInt, p1: BigUInt, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__174Fn.encoded(with: [.uint256(p0), .uint256(p1), .string(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__174Fn.decode(output: result)
 
             switch decoded {
@@ -4049,10 +4049,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__175(p0: BigUInt, p1: String, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__175(p0: BigUInt, p1: String, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__175Fn.encoded(with: [.uint256(p0), .string(p1), .address(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__175Fn.decode(output: result)
 
             switch decoded {
@@ -4072,10 +4072,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__176(p0: EthAddress, p1: BigUInt, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__176(p0: EthAddress, p1: BigUInt, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__176Fn.encoded(with: [.address(p0), .uint256(p1), .address(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__176Fn.decode(output: result)
 
             switch decoded {
@@ -4095,10 +4095,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__177(p0: Bool, p1: String, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__177(p0: Bool, p1: String, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__177Fn.encoded(with: [.bool(p0), .string(p1), .string(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__177Fn.decode(output: result)
 
             switch decoded {
@@ -4118,10 +4118,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__178(p0: Bool, p1: EthAddress, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__178(p0: Bool, p1: EthAddress, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__178Fn.encoded(with: [.bool(p0), .address(p1), .uint256(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__178Fn.decode(output: result)
 
             switch decoded {
@@ -4141,10 +4141,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__179(p0: String, p1: BigUInt, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__179(p0: String, p1: BigUInt, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__179Fn.encoded(with: [.string(p0), .uint256(p1), .string(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__179Fn.decode(output: result)
 
             switch decoded {
@@ -4164,10 +4164,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__180(p0: String, p1: String, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__180(p0: String, p1: String, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__180Fn.encoded(with: [.string(p0), .string(p1), .address(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__180Fn.decode(output: result)
 
             switch decoded {
@@ -4187,10 +4187,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__181(p0: String, p1: BigUInt, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__181(p0: String, p1: BigUInt, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__181Fn.encoded(with: [.string(p0), .uint256(p1), .string(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__181Fn.decode(output: result)
 
             switch decoded {
@@ -4210,10 +4210,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__182(p0: Bool, p1: Bool, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__182(p0: Bool, p1: Bool, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__182Fn.encoded(with: [.bool(p0), .bool(p1), .uint256(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__182Fn.decode(output: result)
 
             switch decoded {
@@ -4233,10 +4233,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__183(p0: Bool, p1: BigUInt, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__183(p0: Bool, p1: BigUInt, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__183Fn.encoded(with: [.bool(p0), .uint256(p1), .bool(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__183Fn.decode(output: result)
 
             switch decoded {
@@ -4256,10 +4256,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__184(p0: String, p1: EthAddress, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__184(p0: String, p1: EthAddress, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__184Fn.encoded(with: [.string(p0), .address(p1), .address(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__184Fn.decode(output: result)
 
             switch decoded {
@@ -4279,10 +4279,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__185(p0: EthAddress, p1: Bool, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__185(p0: EthAddress, p1: Bool, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__185Fn.encoded(with: [.address(p0), .bool(p1), .string(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__185Fn.decode(output: result)
 
             switch decoded {
@@ -4302,10 +4302,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__186(p0: String, p1: BigUInt, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__186(p0: String, p1: BigUInt, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__186Fn.encoded(with: [.string(p0), .uint256(p1), .address(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__186Fn.decode(output: result)
 
             switch decoded {
@@ -4325,10 +4325,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__187(p0: BigUInt, p1: String, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__187(p0: BigUInt, p1: String, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__187Fn.encoded(with: [.uint256(p0), .string(p1), .uint256(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__187Fn.decode(output: result)
 
             switch decoded {
@@ -4348,10 +4348,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__188(p0: EthAddress, p1: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__188(p0: EthAddress, p1: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__188Fn.encoded(with: [.address(p0), .uint256(p1)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__188Fn.decode(output: result)
 
             switch decoded {
@@ -4371,10 +4371,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__189(p0: String, p1: Bool, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__189(p0: String, p1: Bool, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__189Fn.encoded(with: [.string(p0), .bool(p1), .bool(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__189Fn.decode(output: result)
 
             switch decoded {
@@ -4394,10 +4394,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__190(p0: Bool, p1: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__190(p0: Bool, p1: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__190Fn.encoded(with: [.bool(p0), .address(p1)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__190Fn.decode(output: result)
 
             switch decoded {
@@ -4417,10 +4417,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__191(p0: String, p1: BigUInt, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__191(p0: String, p1: BigUInt, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__191Fn.encoded(with: [.string(p0), .uint256(p1), .uint256(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__191Fn.decode(output: result)
 
             switch decoded {
@@ -4440,10 +4440,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__192(p0: BigUInt, p1: Bool, p2: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__192(p0: BigUInt, p1: Bool, p2: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__192Fn.encoded(with: [.uint256(p0), .bool(p1), .string(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__192Fn.decode(output: result)
 
             switch decoded {
@@ -4463,10 +4463,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__193(p0: EthAddress, p1: BigUInt, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__193(p0: EthAddress, p1: BigUInt, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__193Fn.encoded(with: [.address(p0), .uint256(p1), .string(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__193Fn.decode(output: result)
 
             switch decoded {
@@ -4486,10 +4486,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__194(p0: BigUInt, p1: Bool, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__194(p0: BigUInt, p1: Bool, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__194Fn.encoded(with: [.uint256(p0), .bool(p1), .uint256(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__194Fn.decode(output: result)
 
             switch decoded {
@@ -4509,10 +4509,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__195(p0: BigUInt, p1: BigUInt, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__195(p0: BigUInt, p1: BigUInt, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__195Fn.encoded(with: [.uint256(p0), .uint256(p1), .address(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__195Fn.decode(output: result)
 
             switch decoded {
@@ -4532,10 +4532,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__196(p0: String, p1: Bool, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__196(p0: String, p1: Bool, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__196Fn.encoded(with: [.string(p0), .bool(p1), .bool(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__196Fn.decode(output: result)
 
             switch decoded {
@@ -4555,10 +4555,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__197(p0: String, p1: Bool, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__197(p0: String, p1: Bool, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__197Fn.encoded(with: [.string(p0), .bool(p1), .uint256(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__197Fn.decode(output: result)
 
             switch decoded {
@@ -4578,10 +4578,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__198(p0: Bool, p1: Bool, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__198(p0: Bool, p1: Bool, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__198Fn.encoded(with: [.bool(p0), .bool(p1), .bool(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__198Fn.decode(output: result)
 
             switch decoded {
@@ -4601,10 +4601,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__199(p0: EthAddress, p1: Bool, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__199(p0: EthAddress, p1: Bool, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__199Fn.encoded(with: [.address(p0), .bool(p1), .bool(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__199Fn.decode(output: result)
 
             switch decoded {
@@ -4624,10 +4624,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__200(p0: EthAddress, p1: EthAddress, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__200(p0: EthAddress, p1: EthAddress, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__200Fn.encoded(with: [.address(p0), .address(p1), .uint256(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__200Fn.decode(output: result)
 
             switch decoded {
@@ -4647,10 +4647,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__201(p0: String, p1: Bool, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__201(p0: String, p1: Bool, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__201Fn.encoded(with: [.string(p0), .bool(p1), .bool(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__201Fn.decode(output: result)
 
             switch decoded {
@@ -4670,10 +4670,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__202(p0: Bool, p1: BigUInt, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__202(p0: Bool, p1: BigUInt, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__202Fn.encoded(with: [.bool(p0), .uint256(p1), .uint256(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__202Fn.decode(output: result)
 
             switch decoded {
@@ -4693,10 +4693,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__203(p0: String, p1: String, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__203(p0: String, p1: String, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__203Fn.encoded(with: [.string(p0), .string(p1), .string(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__203Fn.decode(output: result)
 
             switch decoded {
@@ -4716,10 +4716,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__204(p0: String, p1: EthAddress, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__204(p0: String, p1: EthAddress, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__204Fn.encoded(with: [.string(p0), .address(p1), .address(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__204Fn.decode(output: result)
 
             switch decoded {
@@ -4739,10 +4739,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__205(p0: EthAddress, p1: EthAddress, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__205(p0: EthAddress, p1: EthAddress, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__205Fn.encoded(with: [.address(p0), .address(p1), .string(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__205Fn.decode(output: result)
 
             switch decoded {
@@ -4762,10 +4762,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__206(p0: Bool, p1: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__206(p0: Bool, p1: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__206Fn.encoded(with: [.bool(p0), .string(p1)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__206Fn.decode(output: result)
 
             switch decoded {
@@ -4785,10 +4785,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__207(p0: BigUInt, p1: String, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__207(p0: BigUInt, p1: String, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__207Fn.encoded(with: [.uint256(p0), .string(p1), .address(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__207Fn.decode(output: result)
 
             switch decoded {
@@ -4808,10 +4808,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__208(p0: BigUInt, p1: EthAddress, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__208(p0: BigUInt, p1: EthAddress, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__208Fn.encoded(with: [.uint256(p0), .address(p1), .bool(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__208Fn.decode(output: result)
 
             switch decoded {
@@ -4831,10 +4831,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__209(p0: Bool, p1: BigUInt, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__209(p0: Bool, p1: BigUInt, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__209Fn.encoded(with: [.bool(p0), .uint256(p1), .bool(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__209Fn.decode(output: result)
 
             switch decoded {
@@ -4854,10 +4854,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__210(p0: BigUInt, p1: Bool, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__210(p0: BigUInt, p1: Bool, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__210Fn.encoded(with: [.uint256(p0), .bool(p1), .uint256(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__210Fn.decode(output: result)
 
             switch decoded {
@@ -4877,10 +4877,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__211(p0: String, p1: EthAddress, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__211(p0: String, p1: EthAddress, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__211Fn.encoded(with: [.string(p0), .address(p1), .string(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__211Fn.decode(output: result)
 
             switch decoded {
@@ -4900,10 +4900,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__212(p0: String, p1: Bool, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__212(p0: String, p1: Bool, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__212Fn.encoded(with: [.string(p0), .bool(p1), .address(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__212Fn.decode(output: result)
 
             switch decoded {
@@ -4923,10 +4923,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__213(p0: String, p1: Bool, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__213(p0: String, p1: Bool, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__213Fn.encoded(with: [.string(p0), .bool(p1), .uint256(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__213Fn.decode(output: result)
 
             switch decoded {
@@ -4946,10 +4946,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__214(p0: EthAddress, p1: EthAddress, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__214(p0: EthAddress, p1: EthAddress, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__214Fn.encoded(with: [.address(p0), .address(p1), .address(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__214Fn.decode(output: result)
 
             switch decoded {
@@ -4969,10 +4969,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__215(p0: String, p1: Bool, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__215(p0: String, p1: Bool, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__215Fn.encoded(with: [.string(p0), .bool(p1), .address(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__215Fn.decode(output: result)
 
             switch decoded {
@@ -4992,10 +4992,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__216(p0: Bool, p1: String, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__216(p0: Bool, p1: String, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__216Fn.encoded(with: [.bool(p0), .string(p1), .address(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__216Fn.decode(output: result)
 
             switch decoded {
@@ -5015,10 +5015,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__217(p0: String, p1: String, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__217(p0: String, p1: String, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__217Fn.encoded(with: [.string(p0), .string(p1), .address(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__217Fn.decode(output: result)
 
             switch decoded {
@@ -5038,10 +5038,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__218(p0: Bool, p1: String, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__218(p0: Bool, p1: String, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__218Fn.encoded(with: [.bool(p0), .string(p1), .string(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__218Fn.decode(output: result)
 
             switch decoded {
@@ -5061,10 +5061,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__219(p0: BigUInt, p1: BigUInt, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__219(p0: BigUInt, p1: BigUInt, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__219Fn.encoded(with: [.uint256(p0), .uint256(p1), .bool(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__219Fn.decode(output: result)
 
             switch decoded {
@@ -5084,10 +5084,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__220(p0: Bool, p1: BigUInt, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__220(p0: Bool, p1: BigUInt, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__220Fn.encoded(with: [.bool(p0), .uint256(p1), .bool(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__220Fn.decode(output: result)
 
             switch decoded {
@@ -5107,10 +5107,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__221(p0: EthAddress, p1: EthAddress, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__221(p0: EthAddress, p1: EthAddress, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__221Fn.encoded(with: [.address(p0), .address(p1), .uint256(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__221Fn.decode(output: result)
 
             switch decoded {
@@ -5130,10 +5130,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__222(p0: BigUInt, p1: EthAddress, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__222(p0: BigUInt, p1: EthAddress, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__222Fn.encoded(with: [.uint256(p0), .address(p1), .bool(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__222Fn.decode(output: result)
 
             switch decoded {
@@ -5153,10 +5153,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__223(p0: BigUInt, p1: String, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__223(p0: BigUInt, p1: String, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__223Fn.encoded(with: [.uint256(p0), .string(p1), .address(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__223Fn.decode(output: result)
 
             switch decoded {
@@ -5176,10 +5176,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__224(p0: EthAddress, p1: Bool, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__224(p0: EthAddress, p1: Bool, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__224Fn.encoded(with: [.address(p0), .bool(p1), .uint256(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__224Fn.decode(output: result)
 
             switch decoded {
@@ -5199,10 +5199,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__225(p0: BigUInt, p1: EthAddress, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__225(p0: BigUInt, p1: EthAddress, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__225Fn.encoded(with: [.uint256(p0), .address(p1), .string(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__225Fn.decode(output: result)
 
             switch decoded {
@@ -5222,10 +5222,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__226(p0: String, p1: Bool, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__226(p0: String, p1: Bool, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__226Fn.encoded(with: [.string(p0), .bool(p1), .bool(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__226Fn.decode(output: result)
 
             switch decoded {
@@ -5245,10 +5245,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__227(p0: EthAddress, p1: EthAddress, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__227(p0: EthAddress, p1: EthAddress, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__227Fn.encoded(with: [.address(p0), .address(p1), .bool(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__227Fn.decode(output: result)
 
             switch decoded {
@@ -5268,10 +5268,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__228(p0: String, p1: BigUInt, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__228(p0: String, p1: BigUInt, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__228Fn.encoded(with: [.string(p0), .uint256(p1), .address(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__228Fn.decode(output: result)
 
             switch decoded {
@@ -5291,10 +5291,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__229(p0: EthAddress, p1: String, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__229(p0: EthAddress, p1: String, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__229Fn.encoded(with: [.address(p0), .string(p1), .string(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__229Fn.decode(output: result)
 
             switch decoded {
@@ -5314,10 +5314,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__230(p0: Bool, p1: Bool, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__230(p0: Bool, p1: Bool, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__230Fn.encoded(with: [.bool(p0), .bool(p1), .address(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__230Fn.decode(output: result)
 
             switch decoded {
@@ -5337,10 +5337,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__231(p0: EthAddress, p1: BigUInt, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__231(p0: EthAddress, p1: BigUInt, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__231Fn.encoded(with: [.address(p0), .uint256(p1), .address(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__231Fn.decode(output: result)
 
             switch decoded {
@@ -5360,10 +5360,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__232(p0: BigUInt, p1: Bool, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__232(p0: BigUInt, p1: Bool, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__232Fn.encoded(with: [.uint256(p0), .bool(p1), .address(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__232Fn.decode(output: result)
 
             switch decoded {
@@ -5383,10 +5383,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__233(p0: EthAddress, p1: BigUInt, p2: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__233(p0: EthAddress, p1: BigUInt, p2: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__233Fn.encoded(with: [.address(p0), .uint256(p1), .string(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__233Fn.decode(output: result)
 
             switch decoded {
@@ -5406,10 +5406,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__234(p0: EthAddress, p1: BigUInt, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__234(p0: EthAddress, p1: BigUInt, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__234Fn.encoded(with: [.address(p0), .uint256(p1), .bool(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__234Fn.decode(output: result)
 
             switch decoded {
@@ -5429,10 +5429,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__235(p0: BigUInt, p1: BigUInt, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__235(p0: BigUInt, p1: BigUInt, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__235Fn.encoded(with: [.uint256(p0), .uint256(p1), .bool(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__235Fn.decode(output: result)
 
             switch decoded {
@@ -5452,10 +5452,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__236(p0: Bool, p1: String, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__236(p0: Bool, p1: String, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__236Fn.encoded(with: [.bool(p0), .string(p1), .address(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__236Fn.decode(output: result)
 
             switch decoded {
@@ -5475,10 +5475,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__237(p0: EthAddress, p1: Bool, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__237(p0: EthAddress, p1: Bool, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__237Fn.encoded(with: [.address(p0), .bool(p1), .address(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__237Fn.decode(output: result)
 
             switch decoded {
@@ -5498,10 +5498,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__238(p0: Bool, p1: EthAddress, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__238(p0: Bool, p1: EthAddress, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__238Fn.encoded(with: [.bool(p0), .address(p1), .string(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__238Fn.decode(output: result)
 
             switch decoded {
@@ -5521,10 +5521,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__239(p0: EthAddress, p1: Bool, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__239(p0: EthAddress, p1: Bool, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__239Fn.encoded(with: [.address(p0), .bool(p1), .address(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__239Fn.decode(output: result)
 
             switch decoded {
@@ -5544,10 +5544,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__240(p0: String, p1: BigUInt, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__240(p0: String, p1: BigUInt, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__240Fn.encoded(with: [.string(p0), .uint256(p1), .uint256(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__240Fn.decode(output: result)
 
             switch decoded {
@@ -5567,10 +5567,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__241(p0: String, p1: Bool, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__241(p0: String, p1: Bool, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__241Fn.encoded(with: [.string(p0), .bool(p1), .string(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__241Fn.decode(output: result)
 
             switch decoded {
@@ -5590,10 +5590,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__242(p0: EthAddress, p1: EthAddress, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__242(p0: EthAddress, p1: EthAddress, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__242Fn.encoded(with: [.address(p0), .address(p1), .bool(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__242Fn.decode(output: result)
 
             switch decoded {
@@ -5613,10 +5613,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__243(p0: String, p1: EthAddress, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__243(p0: String, p1: EthAddress, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__243Fn.encoded(with: [.string(p0), .address(p1), .string(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__243Fn.decode(output: result)
 
             switch decoded {
@@ -5636,10 +5636,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__244(p0: BigUInt, p1: BigUInt, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__244(p0: BigUInt, p1: BigUInt, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__244Fn.encoded(with: [.uint256(p0), .uint256(p1), .bool(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__244Fn.decode(output: result)
 
             switch decoded {
@@ -5659,10 +5659,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__245(p0: String, p1: BigUInt, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__245(p0: String, p1: BigUInt, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__245Fn.encoded(with: [.string(p0), .uint256(p1), .bool(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__245Fn.decode(output: result)
 
             switch decoded {
@@ -5682,10 +5682,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__246(p0: BigUInt, p1: Bool, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__246(p0: BigUInt, p1: Bool, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__246Fn.encoded(with: [.uint256(p0), .bool(p1), .address(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__246Fn.decode(output: result)
 
             switch decoded {
@@ -5705,10 +5705,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__247(p0: BigUInt, p1: String, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__247(p0: BigUInt, p1: String, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__247Fn.encoded(with: [.uint256(p0), .string(p1), .bool(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__247Fn.decode(output: result)
 
             switch decoded {
@@ -5728,10 +5728,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__248(p0: BigUInt, p1: String, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__248(p0: BigUInt, p1: String, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__248Fn.encoded(with: [.uint256(p0), .string(p1), .string(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__248Fn.decode(output: result)
 
             switch decoded {
@@ -5751,10 +5751,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__249(p0: Bool, p1: String, p2: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__249(p0: Bool, p1: String, p2: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__249Fn.encoded(with: [.bool(p0), .string(p1), .string(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__249Fn.decode(output: result)
 
             switch decoded {
@@ -5774,10 +5774,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__250(p0: String, p1: String, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__250(p0: String, p1: String, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__250Fn.encoded(with: [.string(p0), .string(p1), .bool(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__250Fn.decode(output: result)
 
             switch decoded {
@@ -5797,10 +5797,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__251(p0: BigUInt, p1: String, p2: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__251(p0: BigUInt, p1: String, p2: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__251Fn.encoded(with: [.uint256(p0), .string(p1), .string(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__251Fn.decode(output: result)
 
             switch decoded {
@@ -5820,10 +5820,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__252(p0: BigUInt, p1: String, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__252(p0: BigUInt, p1: String, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__252Fn.encoded(with: [.uint256(p0), .string(p1), .string(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__252Fn.decode(output: result)
 
             switch decoded {
@@ -5843,10 +5843,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__253(p0: Bool, p1: BigUInt, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__253(p0: Bool, p1: BigUInt, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__253Fn.encoded(with: [.bool(p0), .uint256(p1), .address(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__253Fn.decode(output: result)
 
             switch decoded {
@@ -5866,10 +5866,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__254(p0: String, p1: EthAddress, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__254(p0: String, p1: EthAddress, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__254Fn.encoded(with: [.string(p0), .address(p1), .address(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__254Fn.decode(output: result)
 
             switch decoded {
@@ -5889,10 +5889,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__255(p0: String, p1: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__255(p0: String, p1: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__255Fn.encoded(with: [.string(p0), .uint256(p1)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__255Fn.decode(output: result)
 
             switch decoded {
@@ -5912,10 +5912,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__256(p0: EthAddress, p1: BigUInt, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__256(p0: EthAddress, p1: BigUInt, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__256Fn.encoded(with: [.address(p0), .uint256(p1), .uint256(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__256Fn.decode(output: result)
 
             switch decoded {
@@ -5935,10 +5935,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__257(p0: BigUInt, p1: Bool, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__257(p0: BigUInt, p1: Bool, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__257Fn.encoded(with: [.uint256(p0), .bool(p1), .bool(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__257Fn.decode(output: result)
 
             switch decoded {
@@ -5958,10 +5958,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__258(p0: BigUInt, p1: String, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__258(p0: BigUInt, p1: String, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__258Fn.encoded(with: [.uint256(p0), .string(p1), .uint256(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__258Fn.decode(output: result)
 
             switch decoded {
@@ -5981,10 +5981,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__259(p0: Bool, p1: Bool, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__259(p0: Bool, p1: Bool, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__259Fn.encoded(with: [.bool(p0), .bool(p1), .string(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__259Fn.decode(output: result)
 
             switch decoded {
@@ -6004,10 +6004,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__260(p0: BigUInt, p1: String, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__260(p0: BigUInt, p1: String, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__260Fn.encoded(with: [.uint256(p0), .string(p1), .bool(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__260Fn.decode(output: result)
 
             switch decoded {
@@ -6027,10 +6027,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__261(p0: EthAddress, p1: String, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__261(p0: EthAddress, p1: String, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__261Fn.encoded(with: [.address(p0), .string(p1), .bool(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__261Fn.decode(output: result)
 
             switch decoded {
@@ -6050,10 +6050,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__262(p0: BigUInt, p1: EthAddress, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__262(p0: BigUInt, p1: EthAddress, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__262Fn.encoded(with: [.uint256(p0), .address(p1), .address(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__262Fn.decode(output: result)
 
             switch decoded {
@@ -6073,10 +6073,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__263(p0: EthAddress, p1: EthAddress, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__263(p0: EthAddress, p1: EthAddress, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__263Fn.encoded(with: [.address(p0), .address(p1), .uint256(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__263Fn.decode(output: result)
 
             switch decoded {
@@ -6096,10 +6096,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__264(p0: Bool, p1: BigUInt, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__264(p0: Bool, p1: BigUInt, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__264Fn.encoded(with: [.bool(p0), .uint256(p1), .uint256(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__264Fn.decode(output: result)
 
             switch decoded {
@@ -6119,10 +6119,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__265(p0: EthAddress, p1: BigUInt, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__265(p0: EthAddress, p1: BigUInt, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__265Fn.encoded(with: [.address(p0), .uint256(p1), .string(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__265Fn.decode(output: result)
 
             switch decoded {
@@ -6142,10 +6142,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__266(p0: Bool, p1: Bool, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__266(p0: Bool, p1: Bool, p2: EthAddress, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__266Fn.encoded(with: [.bool(p0), .bool(p1), .address(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__266Fn.decode(output: result)
 
             switch decoded {
@@ -6165,10 +6165,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__267(p0: Bool, p1: EthAddress, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__267(p0: Bool, p1: EthAddress, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__267Fn.encoded(with: [.bool(p0), .address(p1), .string(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__267Fn.decode(output: result)
 
             switch decoded {
@@ -6188,10 +6188,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__268(p0: String, p1: String, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__268(p0: String, p1: String, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__268Fn.encoded(with: [.string(p0), .string(p1), .bool(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__268Fn.decode(output: result)
 
             switch decoded {
@@ -6211,10 +6211,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__269(p0: String, p1: String, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__269(p0: String, p1: String, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__269Fn.encoded(with: [.string(p0), .string(p1), .uint256(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__269Fn.decode(output: result)
 
             switch decoded {
@@ -6234,10 +6234,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__270(p0: String, p1: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__270(p0: String, p1: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__270Fn.encoded(with: [.string(p0), .bool(p1)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__270Fn.decode(output: result)
 
             switch decoded {
@@ -6257,10 +6257,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__271(p0: Bool, p1: BigUInt, p2: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__271(p0: Bool, p1: BigUInt, p2: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__271Fn.encoded(with: [.bool(p0), .uint256(p1), .string(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__271Fn.decode(output: result)
 
             switch decoded {
@@ -6280,10 +6280,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__272(p0: EthAddress, p1: Bool, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__272(p0: EthAddress, p1: Bool, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__272Fn.encoded(with: [.address(p0), .bool(p1), .uint256(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__272Fn.decode(output: result)
 
             switch decoded {
@@ -6303,10 +6303,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__273(p0: BigUInt, p1: BigUInt, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__273(p0: BigUInt, p1: BigUInt, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__273Fn.encoded(with: [.uint256(p0), .uint256(p1), .uint256(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__273Fn.decode(output: result)
 
             switch decoded {
@@ -6326,10 +6326,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__274(p0: EthAddress, p1: BigUInt, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__274(p0: EthAddress, p1: BigUInt, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__274Fn.encoded(with: [.address(p0), .uint256(p1), .bool(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__274Fn.decode(output: result)
 
             switch decoded {
@@ -6349,10 +6349,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__275(p0: String, p1: BigUInt, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__275(p0: String, p1: BigUInt, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__275Fn.encoded(with: [.string(p0), .uint256(p1), .string(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__275Fn.decode(output: result)
 
             switch decoded {
@@ -6372,10 +6372,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__276(p0: BigUInt, p1: Bool, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__276(p0: BigUInt, p1: Bool, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__276Fn.encoded(with: [.uint256(p0), .bool(p1), .uint256(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__276Fn.decode(output: result)
 
             switch decoded {
@@ -6395,10 +6395,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__277(p0: String, p1: EthAddress, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__277(p0: String, p1: EthAddress, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__277Fn.encoded(with: [.string(p0), .address(p1), .bool(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__277Fn.decode(output: result)
 
             switch decoded {
@@ -6418,10 +6418,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__278(p0: String, p1: Bool, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__278(p0: String, p1: Bool, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__278Fn.encoded(with: [.string(p0), .bool(p1), .uint256(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__278Fn.decode(output: result)
 
             switch decoded {
@@ -6441,10 +6441,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__279(p0: String, p1: BigUInt, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__279(p0: String, p1: BigUInt, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__279Fn.encoded(with: [.string(p0), .uint256(p1), .uint256(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__279Fn.decode(output: result)
 
             switch decoded {
@@ -6464,10 +6464,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__280(p0: String, p1: BigUInt, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__280(p0: String, p1: BigUInt, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__280Fn.encoded(with: [.string(p0), .uint256(p1), .bool(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__280Fn.decode(output: result)
 
             switch decoded {
@@ -6487,10 +6487,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__281(p0: EthAddress, p1: Bool, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__281(p0: EthAddress, p1: Bool, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__281Fn.encoded(with: [.address(p0), .bool(p1), .bool(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__281Fn.decode(output: result)
 
             switch decoded {
@@ -6510,10 +6510,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__282(p0: BigUInt, p1: EthAddress, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__282(p0: BigUInt, p1: EthAddress, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__282Fn.encoded(with: [.uint256(p0), .address(p1), .string(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__282Fn.decode(output: result)
 
             switch decoded {
@@ -6533,10 +6533,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__283(p0: EthAddress, p1: Bool, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__283(p0: EthAddress, p1: Bool, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__283Fn.encoded(with: [.address(p0), .bool(p1), .uint256(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__283Fn.decode(output: result)
 
             switch decoded {
@@ -6556,10 +6556,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__284(p0: Bool, p1: BigUInt, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__284(p0: Bool, p1: BigUInt, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__284Fn.encoded(with: [.bool(p0), .uint256(p1), .bool(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__284Fn.decode(output: result)
 
             switch decoded {
@@ -6579,10 +6579,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__285(p0: BigUInt, p1: String, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__285(p0: BigUInt, p1: String, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__285Fn.encoded(with: [.uint256(p0), .string(p1), .bool(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__285Fn.decode(output: result)
 
             switch decoded {
@@ -6602,10 +6602,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__286(p0: EthAddress, p1: String, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__286(p0: EthAddress, p1: String, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__286Fn.encoded(with: [.address(p0), .string(p1), .bool(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__286Fn.decode(output: result)
 
             switch decoded {
@@ -6625,10 +6625,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__287(p0: EthAddress, p1: BigUInt, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__287(p0: EthAddress, p1: BigUInt, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__287Fn.encoded(with: [.address(p0), .uint256(p1), .string(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__287Fn.decode(output: result)
 
             switch decoded {
@@ -6648,10 +6648,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__288(p0: EthAddress, p1: Bool, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__288(p0: EthAddress, p1: Bool, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__288Fn.encoded(with: [.address(p0), .bool(p1), .bool(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__288Fn.decode(output: result)
 
             switch decoded {
@@ -6671,10 +6671,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__289(p0: BigUInt, p1: BigUInt, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__289(p0: BigUInt, p1: BigUInt, p2: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__289Fn.encoded(with: [.uint256(p0), .uint256(p1), .uint256(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__289Fn.decode(output: result)
 
             switch decoded {
@@ -6694,10 +6694,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__290(p0: Bool, p1: EthAddress, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__290(p0: Bool, p1: EthAddress, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__290Fn.encoded(with: [.bool(p0), .address(p1), .address(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__290Fn.decode(output: result)
 
             switch decoded {
@@ -6717,10 +6717,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__291(p0: BigUInt, p1: String, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__291(p0: BigUInt, p1: String, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__291Fn.encoded(with: [.uint256(p0), .string(p1), .bool(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__291Fn.decode(output: result)
 
             switch decoded {
@@ -6740,10 +6740,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__292(p0: BigUInt, p1: String, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__292(p0: BigUInt, p1: String, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__292Fn.encoded(with: [.uint256(p0), .string(p1), .string(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__292Fn.decode(output: result)
 
             switch decoded {
@@ -6763,10 +6763,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__293(p0: Bool, p1: EthAddress, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__293(p0: Bool, p1: EthAddress, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__293Fn.encoded(with: [.bool(p0), .address(p1), .uint256(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__293Fn.decode(output: result)
 
             switch decoded {
@@ -6786,10 +6786,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__294(p0: String, p1: String, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__294(p0: String, p1: String, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__294Fn.encoded(with: [.string(p0), .string(p1), .bool(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__294Fn.decode(output: result)
 
             switch decoded {
@@ -6809,10 +6809,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__295(p0: Bool, p1: EthAddress, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__295(p0: Bool, p1: EthAddress, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__295Fn.encoded(with: [.bool(p0), .address(p1), .address(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__295Fn.decode(output: result)
 
             switch decoded {
@@ -6832,10 +6832,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__296(p0: EthAddress, p1: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__296(p0: EthAddress, p1: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__296Fn.encoded(with: [.address(p0), .address(p1)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__296Fn.decode(output: result)
 
             switch decoded {
@@ -6855,10 +6855,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__297(p0: Bool, p1: String, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__297(p0: Bool, p1: String, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__297Fn.encoded(with: [.bool(p0), .string(p1), .bool(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__297Fn.decode(output: result)
 
             switch decoded {
@@ -6878,10 +6878,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__298(p0: Bool, p1: String, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__298(p0: Bool, p1: String, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__298Fn.encoded(with: [.bool(p0), .string(p1), .bool(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__298Fn.decode(output: result)
 
             switch decoded {
@@ -6901,10 +6901,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__299(p0: BigUInt, p1: EthAddress, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__299(p0: BigUInt, p1: EthAddress, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__299Fn.encoded(with: [.uint256(p0), .address(p1), .uint256(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__299Fn.decode(output: result)
 
             switch decoded {
@@ -6924,10 +6924,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__300(p0: BigUInt, p1: Bool, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__300(p0: BigUInt, p1: Bool, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__300Fn.encoded(with: [.uint256(p0), .bool(p1), .bool(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__300Fn.decode(output: result)
 
             switch decoded {
@@ -6947,10 +6947,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__301(p0: BigUInt, p1: Bool, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__301(p0: BigUInt, p1: Bool, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__301Fn.encoded(with: [.uint256(p0), .bool(p1), .uint256(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__301Fn.decode(output: result)
 
             switch decoded {
@@ -6970,10 +6970,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__302(p0: String, p1: String, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__302(p0: String, p1: String, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__302Fn.encoded(with: [.string(p0), .string(p1), .string(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__302Fn.decode(output: result)
 
             switch decoded {
@@ -6993,10 +6993,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__303(p0: Bool, p1: EthAddress, p2: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__303(p0: Bool, p1: EthAddress, p2: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__303Fn.encoded(with: [.bool(p0), .address(p1), .string(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__303Fn.decode(output: result)
 
             switch decoded {
@@ -7016,10 +7016,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__304(p0: EthAddress, p1: Bool, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__304(p0: EthAddress, p1: Bool, p2: Bool, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__304Fn.encoded(with: [.address(p0), .bool(p1), .bool(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__304Fn.decode(output: result)
 
             switch decoded {
@@ -7039,10 +7039,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__305(p0: String, p1: Bool, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__305(p0: String, p1: Bool, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__305Fn.encoded(with: [.string(p0), .bool(p1), .string(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__305Fn.decode(output: result)
 
             switch decoded {
@@ -7062,10 +7062,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__306(p0: String, p1: BigUInt, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__306(p0: String, p1: BigUInt, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__306Fn.encoded(with: [.string(p0), .uint256(p1), .bool(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__306Fn.decode(output: result)
 
             switch decoded {
@@ -7085,10 +7085,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__307(p0: String, p1: EthAddress, p2: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__307(p0: String, p1: EthAddress, p2: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__307Fn.encoded(with: [.string(p0), .address(p1), .string(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__307Fn.decode(output: result)
 
             switch decoded {
@@ -7108,10 +7108,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__308(p0: String, p1: BigUInt, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__308(p0: String, p1: BigUInt, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__308Fn.encoded(with: [.string(p0), .uint256(p1), .uint256(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__308Fn.decode(output: result)
 
             switch decoded {
@@ -7131,10 +7131,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__309(p0: String, p1: Bool, p2: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__309(p0: String, p1: Bool, p2: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__309Fn.encoded(with: [.string(p0), .bool(p1), .string(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__309Fn.decode(output: result)
 
             switch decoded {
@@ -7154,10 +7154,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__310(p0: Bool, p1: EthAddress, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__310(p0: Bool, p1: EthAddress, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__310Fn.encoded(with: [.bool(p0), .address(p1), .string(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__310Fn.decode(output: result)
 
             switch decoded {
@@ -7177,10 +7177,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__311(p0: BigUInt, p1: EthAddress, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__311(p0: BigUInt, p1: EthAddress, p2: Bool, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__311Fn.encoded(with: [.uint256(p0), .address(p1), .bool(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__311Fn.decode(output: result)
 
             switch decoded {
@@ -7200,10 +7200,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__312(p0: Bool, p1: Bool, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__312(p0: Bool, p1: Bool, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__312Fn.encoded(with: [.bool(p0), .bool(p1), .string(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__312Fn.decode(output: result)
 
             switch decoded {
@@ -7223,10 +7223,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__313(p0: String, p1: BigUInt, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__313(p0: String, p1: BigUInt, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__313Fn.encoded(with: [.string(p0), .uint256(p1), .bool(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__313Fn.decode(output: result)
 
             switch decoded {
@@ -7246,10 +7246,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__314(p0: Bool, p1: BigUInt, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__314(p0: Bool, p1: BigUInt, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__314Fn.encoded(with: [.bool(p0), .uint256(p1), .string(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__314Fn.decode(output: result)
 
             switch decoded {
@@ -7269,10 +7269,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__315(p0: BigUInt, p1: String, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__315(p0: BigUInt, p1: String, p2: EthAddress, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__315Fn.encoded(with: [.uint256(p0), .string(p1), .address(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__315Fn.decode(output: result)
 
             switch decoded {
@@ -7292,10 +7292,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__316(p0: Bool, p1: BigUInt, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__316(p0: Bool, p1: BigUInt, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__316Fn.encoded(with: [.bool(p0), .uint256(p1), .bool(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__316Fn.decode(output: result)
 
             switch decoded {
@@ -7315,10 +7315,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__317(p0: String, p1: String, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__317(p0: String, p1: String, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__317Fn.encoded(with: [.string(p0), .string(p1), .address(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__317Fn.decode(output: result)
 
             switch decoded {
@@ -7338,10 +7338,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__318(p0: BigUInt, p1: BigUInt, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__318(p0: BigUInt, p1: BigUInt, p2: Bool, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__318Fn.encoded(with: [.uint256(p0), .uint256(p1), .bool(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__318Fn.decode(output: result)
 
             switch decoded {
@@ -7361,10 +7361,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__319(p0: EthAddress, p1: Bool, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__319(p0: EthAddress, p1: Bool, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__319Fn.encoded(with: [.address(p0), .bool(p1), .bool(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__319Fn.decode(output: result)
 
             switch decoded {
@@ -7384,10 +7384,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__320(p0: BigUInt, p1: Bool, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__320(p0: BigUInt, p1: Bool, p2: String, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__320Fn.encoded(with: [.uint256(p0), .bool(p1), .string(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__320Fn.decode(output: result)
 
             switch decoded {
@@ -7407,10 +7407,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__321(p0: String, p1: EthAddress, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__321(p0: String, p1: EthAddress, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__321Fn.encoded(with: [.string(p0), .address(p1), .address(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__321Fn.decode(output: result)
 
             switch decoded {
@@ -7430,10 +7430,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__322(p0: EthAddress, p1: EthAddress, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__322(p0: EthAddress, p1: EthAddress, p2: String, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__322Fn.encoded(with: [.address(p0), .address(p1), .string(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__322Fn.decode(output: result)
 
             switch decoded {
@@ -7453,10 +7453,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__323(p0: BigUInt, p1: Bool, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__323(p0: BigUInt, p1: Bool, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__323Fn.encoded(with: [.uint256(p0), .bool(p1), .string(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__323Fn.decode(output: result)
 
             switch decoded {
@@ -7476,10 +7476,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__324(p0: BigUInt, p1: EthAddress, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__324(p0: BigUInt, p1: EthAddress, p2: Bool, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__324Fn.encoded(with: [.uint256(p0), .address(p1), .bool(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__324Fn.decode(output: result)
 
             switch decoded {
@@ -7499,10 +7499,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__325(p0: EthAddress, p1: String, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__325(p0: EthAddress, p1: String, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__325Fn.encoded(with: [.address(p0), .string(p1), .address(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__325Fn.decode(output: result)
 
             switch decoded {
@@ -7522,10 +7522,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__326(p0: EthAddress, p1: Bool, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__326(p0: EthAddress, p1: Bool, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__326Fn.encoded(with: [.address(p0), .bool(p1), .address(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__326Fn.decode(output: result)
 
             switch decoded {
@@ -7545,10 +7545,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__327(p0: EthAddress, p1: EthAddress, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__327(p0: EthAddress, p1: EthAddress, p2: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__327Fn.encoded(with: [.address(p0), .address(p1), .bool(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__327Fn.decode(output: result)
 
             switch decoded {
@@ -7568,10 +7568,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__328(p0: String, p1: String, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__328(p0: String, p1: String, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__328Fn.encoded(with: [.string(p0), .string(p1), .uint256(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__328Fn.decode(output: result)
 
             switch decoded {
@@ -7591,10 +7591,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__329(p0: Bool, p1: Bool, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__329(p0: Bool, p1: Bool, p2: EthAddress, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__329Fn.encoded(with: [.bool(p0), .bool(p1), .address(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__329Fn.decode(output: result)
 
             switch decoded {
@@ -7614,10 +7614,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__330(p0: Bool, p1: BigUInt, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__330(p0: Bool, p1: BigUInt, p2: String, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__330Fn.encoded(with: [.bool(p0), .uint256(p1), .string(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__330Fn.decode(output: result)
 
             switch decoded {
@@ -7637,10 +7637,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__331(p0: BigUInt, p1: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__331(p0: BigUInt, p1: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__331Fn.encoded(with: [.uint256(p0), .uint256(p1)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__331Fn.decode(output: result)
 
             switch decoded {
@@ -7660,10 +7660,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__332(p0: EthAddress, p1: String, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__332(p0: EthAddress, p1: String, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__332Fn.encoded(with: [.address(p0), .string(p1), .address(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__332Fn.decode(output: result)
 
             switch decoded {
@@ -7683,10 +7683,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__333(p0: EthAddress, p1: EthAddress, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__333(p0: EthAddress, p1: EthAddress, p2: EthAddress, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__333Fn.encoded(with: [.address(p0), .address(p1), .address(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__333Fn.decode(output: result)
 
             switch decoded {
@@ -7706,10 +7706,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__334(p0: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__334(p0: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__334Fn.encoded(with: [.uint256(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__334Fn.decode(output: result)
 
             switch decoded {
@@ -7729,10 +7729,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__335(p0: String, p1: EthAddress, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__335(p0: String, p1: EthAddress, p2: BigUInt, p3: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__335Fn.encoded(with: [.string(p0), .address(p1), .uint256(p2), .uint256(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__335Fn.decode(output: result)
 
             switch decoded {
@@ -7752,10 +7752,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__336(p0: Bool, p1: Bool, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__336(p0: Bool, p1: Bool, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__336Fn.encoded(with: [.bool(p0), .bool(p1), .string(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__336Fn.decode(output: result)
 
             switch decoded {
@@ -7775,10 +7775,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__337(p0: BigUInt, p1: BigUInt, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__337(p0: BigUInt, p1: BigUInt, p2: BigUInt, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__337Fn.encoded(with: [.uint256(p0), .uint256(p1), .uint256(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__337Fn.decode(output: result)
 
             switch decoded {
@@ -7798,10 +7798,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__338(p0: EthAddress, p1: String, p2: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__338(p0: EthAddress, p1: String, p2: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__338Fn.encoded(with: [.address(p0), .string(p1), .string(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__338Fn.decode(output: result)
 
             switch decoded {
@@ -7821,10 +7821,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__339(p0: String, p1: EthAddress, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__339(p0: String, p1: EthAddress, p2: BigUInt, p3: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__339Fn.encoded(with: [.string(p0), .address(p1), .uint256(p2), .bool(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__339Fn.decode(output: result)
 
             switch decoded {
@@ -7844,10 +7844,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__340(p0: String, p1: EthAddress, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__340(p0: String, p1: EthAddress, p2: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__340Fn.encoded(with: [.string(p0), .address(p1), .address(p2)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__340Fn.decode(output: result)
 
             switch decoded {
@@ -7867,10 +7867,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__341(p0: EthAddress, p1: EthAddress, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__341(p0: EthAddress, p1: EthAddress, p2: BigUInt, p3: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__341Fn.encoded(with: [.address(p0), .address(p1), .uint256(p2), .string(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__341Fn.decode(output: result)
 
             switch decoded {
@@ -7890,10 +7890,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func log__342(p0: Bool, p1: BigUInt, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func log__342(p0: Bool, p1: BigUInt, p2: String, p3: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try log__342Fn.encoded(with: [.bool(p0), .uint256(p1), .string(p2), .address(p3)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try log__342Fn.decode(output: result)
 
             switch decoded {
@@ -7913,10 +7913,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logAddress(p0: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logAddress(p0: EthAddress, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logAddressFn.encoded(with: [.address(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logAddressFn.decode(output: result)
 
             switch decoded {
@@ -7936,10 +7936,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBool(p0: Bool, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBool(p0: Bool, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBoolFn.encoded(with: [.bool(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBoolFn.decode(output: result)
 
             switch decoded {
@@ -7959,10 +7959,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytesFn.encoded(with: [.bytes(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytesFn.decode(output: result)
 
             switch decoded {
@@ -7982,10 +7982,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes1(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes1(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes1Fn.encoded(with: [.bytes1(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes1Fn.decode(output: result)
 
             switch decoded {
@@ -8005,10 +8005,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes10(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes10(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes10Fn.encoded(with: [.bytes10(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes10Fn.decode(output: result)
 
             switch decoded {
@@ -8028,10 +8028,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes11(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes11(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes11Fn.encoded(with: [.bytes11(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes11Fn.decode(output: result)
 
             switch decoded {
@@ -8051,10 +8051,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes12(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes12(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes12Fn.encoded(with: [.bytes12(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes12Fn.decode(output: result)
 
             switch decoded {
@@ -8074,10 +8074,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes13(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes13(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes13Fn.encoded(with: [.bytes13(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes13Fn.decode(output: result)
 
             switch decoded {
@@ -8097,10 +8097,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes14(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes14(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes14Fn.encoded(with: [.bytes14(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes14Fn.decode(output: result)
 
             switch decoded {
@@ -8120,10 +8120,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes15(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes15(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes15Fn.encoded(with: [.bytes15(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes15Fn.decode(output: result)
 
             switch decoded {
@@ -8143,10 +8143,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes16(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes16(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes16Fn.encoded(with: [.bytes16(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes16Fn.decode(output: result)
 
             switch decoded {
@@ -8166,10 +8166,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes17(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes17(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes17Fn.encoded(with: [.bytes17(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes17Fn.decode(output: result)
 
             switch decoded {
@@ -8189,10 +8189,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes18(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes18(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes18Fn.encoded(with: [.bytes18(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes18Fn.decode(output: result)
 
             switch decoded {
@@ -8212,10 +8212,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes19(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes19(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes19Fn.encoded(with: [.bytes19(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes19Fn.decode(output: result)
 
             switch decoded {
@@ -8235,10 +8235,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes2(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes2(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes2Fn.encoded(with: [.bytes2(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes2Fn.decode(output: result)
 
             switch decoded {
@@ -8258,10 +8258,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes20(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes20(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes20Fn.encoded(with: [.bytes20(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes20Fn.decode(output: result)
 
             switch decoded {
@@ -8281,10 +8281,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes21(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes21(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes21Fn.encoded(with: [.bytes21(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes21Fn.decode(output: result)
 
             switch decoded {
@@ -8304,10 +8304,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes22(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes22(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes22Fn.encoded(with: [.bytes22(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes22Fn.decode(output: result)
 
             switch decoded {
@@ -8327,10 +8327,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes23(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes23(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes23Fn.encoded(with: [.bytes23(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes23Fn.decode(output: result)
 
             switch decoded {
@@ -8350,10 +8350,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes24(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes24(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes24Fn.encoded(with: [.bytes24(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes24Fn.decode(output: result)
 
             switch decoded {
@@ -8373,10 +8373,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes25(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes25(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes25Fn.encoded(with: [.bytes25(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes25Fn.decode(output: result)
 
             switch decoded {
@@ -8396,10 +8396,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes26(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes26(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes26Fn.encoded(with: [.bytes26(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes26Fn.decode(output: result)
 
             switch decoded {
@@ -8419,10 +8419,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes27(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes27(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes27Fn.encoded(with: [.bytes27(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes27Fn.decode(output: result)
 
             switch decoded {
@@ -8442,10 +8442,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes28(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes28(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes28Fn.encoded(with: [.bytes28(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes28Fn.decode(output: result)
 
             switch decoded {
@@ -8465,10 +8465,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes29(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes29(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes29Fn.encoded(with: [.bytes29(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes29Fn.decode(output: result)
 
             switch decoded {
@@ -8488,10 +8488,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes3(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes3(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes3Fn.encoded(with: [.bytes3(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes3Fn.decode(output: result)
 
             switch decoded {
@@ -8511,10 +8511,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes30(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes30(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes30Fn.encoded(with: [.bytes30(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes30Fn.decode(output: result)
 
             switch decoded {
@@ -8534,10 +8534,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes31(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes31(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes31Fn.encoded(with: [.bytes31(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes31Fn.decode(output: result)
 
             switch decoded {
@@ -8557,10 +8557,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes32(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes32(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes32Fn.encoded(with: [.bytes32(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes32Fn.decode(output: result)
 
             switch decoded {
@@ -8580,10 +8580,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes4(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes4(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes4Fn.encoded(with: [.bytes4(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes4Fn.decode(output: result)
 
             switch decoded {
@@ -8603,10 +8603,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes5(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes5(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes5Fn.encoded(with: [.bytes5(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes5Fn.decode(output: result)
 
             switch decoded {
@@ -8626,10 +8626,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes6(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes6(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes6Fn.encoded(with: [.bytes6(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes6Fn.decode(output: result)
 
             switch decoded {
@@ -8649,10 +8649,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes7(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes7(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes7Fn.encoded(with: [.bytes7(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes7Fn.decode(output: result)
 
             switch decoded {
@@ -8672,10 +8672,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes8(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes8(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes8Fn.encoded(with: [.bytes8(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes8Fn.decode(output: result)
 
             switch decoded {
@@ -8695,10 +8695,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logBytes9(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logBytes9(p0: Hex, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logBytes9Fn.encoded(with: [.bytes9(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logBytes9Fn.decode(output: result)
 
             switch decoded {
@@ -8718,10 +8718,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logInt(p0: BigInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logInt(p0: BigInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logIntFn.encoded(with: [.int256(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logIntFn.decode(output: result)
 
             switch decoded {
@@ -8741,10 +8741,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logString(p0: String, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logString(p0: String, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logStringFn.encoded(with: [.string(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logStringFn.decode(output: result)
 
             switch decoded {
@@ -8764,10 +8764,10 @@ public enum IConsole {
         outputs: []
     )
 
-    public static func logUint(p0: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) async throws -> Result<Void, RevertReason> {
+    public static func logUint(p0: BigUInt, withFunctions ffis: EVM.FFIMap = [:]) throws -> Result<Void, RevertReason> {
         do {
             let query = try logUintFn.encoded(with: [.uint256(p0)])
-            let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+            let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
             let decoded = try logUintFn.decode(output: result)
 
             switch decoded {

--- a/Sources/Geno/Geno.swift
+++ b/Sources/Geno/Geno.swift
@@ -181,12 +181,12 @@ func generateFunctionDeclaration(f: Contract.ABI.Function, contractName: String)
     }
 
     return try! FunctionDeclSyntax("""
-    public static func \(raw: f.name)(\(raw: parameters.joined(separator: ", "))) async throws -> Result<\(raw: outputs), RevertReason>
+    public static func \(raw: f.name)(\(raw: parameters.joined(separator: ", "))) throws -> Result<\(raw: outputs), RevertReason>
     """) {
         StmtSyntax("""
                 do {
                     let query = try \(raw: f.name)Fn.encoded(with: [\(raw: callParameters(f: f, contractName: contractName))])
-                    let result = try await EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
+                    let result = try EVM.runQuery(bytecode: runtimeCode, query: query, withErrors: errors, withFunctions: ffis)
                     let decoded = try \(raw: f.name)Fn.decode(output: result)
 
                     switch decoded {


### PR DESCRIPTION
This patch makes the EVM synchronous again. We switch back to non-async FFIs. Technically we could have two codepaths for async and sync, but it's not really very easy to color the functions all the way down to make this work, so synchronous seems better for now.