### PR TITLE
Add Number Extensions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/legend-hq/SwiftNumber", branch: "4c311f4e0a09bd8aa3245dadc1d0c0f5c7f83553"),
+        .package(url: "https://github.com/legend-hq/SwiftNumber", branch: "5b0d750800b4f526e7ab057ef169ed617cf4e25b"),
         .package(url: "https://github.com/hayesgm/SwiftKeccak.git", branch: "98a9d4a037dd62283977d5e0ef7d11c5612ff813"),
         .package(url: "https://github.com/apple/swift-syntax.git", from: "601.0.1"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0"),

--- a/Sources/Eth/Number+Uint256.swift
+++ b/Sources/Eth/Number+Uint256.swift
@@ -1,0 +1,10 @@
+import Foundation
+import SwiftNumber
+
+public extension Number {
+    static let MAX_UINT_256: Number = "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+
+    var isMaxUint256: Bool {
+        self == Number.MAX_UINT_256
+    }
+}


### PR DESCRIPTION
This patch bumps the version of `SwiftNumber` we're using, and adds some very simple helpers on `Number` to get `maxUint256`.