### PR TITLE
Add EIP-712 support for typed structured data hashing and signing

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c94a847dca77ce64ac20533763bf37125b206dfbc316b3715a728bef3ab1c88b",
+  "originHash" : "1e2f0437ba3dca98b89568200e3855554e686cb30d26a681affd9a4c046e618f",
   "pins" : [
     {
       "identity" : "swift-docc-plugin",
@@ -41,7 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/legend-hq/SwiftNumber",
       "state" : {
-        "revision" : "8fc7275585a9b7166e8da7a600aae1456e8a6df0"
+        "revision" : "9f78361c6e8df2e77bb31ffd48011da60c18844c"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/legend-hq/SwiftNumber", branch: "8fc7275585a9b7166e8da7a600aae1456e8a6df0"),
+        .package(url: "https://github.com/legend-hq/SwiftNumber", branch: "9f78361c6e8df2e77bb31ffd48011da60c18844c"),
         .package(url: "https://github.com/hayesgm/SwiftKeccak.git", branch: "98a9d4a037dd62283977d5e0ef7d11c5612ff813"),
         .package(url: "https://github.com/apple/swift-syntax.git", from: "601.0.1"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0"),

--- a/Sources/Eth/ABI/EIP712.swift
+++ b/Sources/Eth/ABI/EIP712.swift
@@ -1,0 +1,1089 @@
+//
+//  EIP712.swift
+//  Eth
+//
+//  EIP-712: Typed structured data hashing and signing
+//  https://eips.ethereum.org/EIPS/eip-712
+//
+
+import Foundation
+import SwiftKeccak
+import SwiftNumber
+
+extension ABI {
+  public enum EIP712 {
+    // MARK: - Core Types
+
+    /// Represents EIP-712 typed data that can be signed
+    public struct TypedData: Equatable, Sendable {
+      public let domain: Domain
+      public let types: [String: TypeDefinition]
+      public let primaryType: String
+      public let message: [String: Value]
+
+      public init(
+        domain: Domain,
+        types: [String: TypeDefinition],
+        primaryType: String,
+        message: [String: Value]
+      ) {
+        self.domain = domain
+        self.types = types
+        self.primaryType = primaryType
+        self.message = message
+      }
+
+      /// Encodes the typed data for signing (returns the full encoded message with 0x1901 prefix)
+      public var encoded: Data {
+        get throws {
+          let domainSeparator = try domainSeparator()
+          let messageHash = try hashStruct(typeName: primaryType, data: message)
+
+          var result = Data()
+          result.append(0x19)
+          result.append(0x01)
+          result.append(domainSeparator.data)
+          result.append(messageHash.data)
+          return result
+        }
+      }
+
+      /// Returns the digest hash that should be signed (keccak256 of the encoded data)
+      public var digest: Hex {
+        get throws {
+          Hex(SwiftKeccak.keccak256(try encoded))
+        }
+      }
+
+      /// Returns all EIP-712 hash components separately
+      /// - Returns: A tuple containing:
+      ///   - domainSeparator: 32-byte keccak256 hash of the domain struct
+      ///   - hashStruct: 32-byte keccak256 hash of the message struct
+      ///   - digest: 32-byte keccak256 hash of the full encoded message (0x1901 || domainSeparator || hashStruct)
+      public func components() throws -> (domainSeparator: Hex, hashStruct: Hex, digest: Hex) {
+        let domainSep = try domainSeparator()  // Already returns keccak256 hash
+        let messageHash = try hashStruct(typeName: primaryType, data: message)  // Already returns keccak256 hash
+        let fullDigest = try digest
+
+        return (domainSeparator: domainSep, hashStruct: messageHash, digest: fullDigest)
+      }
+
+      /// Returns the domain separator hash
+      public func domainSeparator() throws -> Hex {
+        let domainTypes = domain.domainType()
+        let domainData = try domain.toValues()
+
+        var allTypes = types
+        allTypes["EIP712Domain"] = domainTypes
+
+        return try Self.hashStruct(typeName: "EIP712Domain", data: domainData, types: allTypes)
+      }
+
+      /// Hashes a struct value according to EIP-712 spec
+      public func hashStruct(typeName: String, data: [String: Value]) throws -> Hex {
+        try Self.hashStruct(typeName: typeName, data: data, types: types)
+      }
+
+      /// Static version for internal use
+      static func hashStruct(
+        typeName: String,
+        data: [String: Value],
+        types: [String: TypeDefinition]
+      ) throws -> Hex {
+        guard let type = types[typeName] else {
+          throw Error.missingType(typeName)
+        }
+
+        let encodedType = try encodeType(typeName, types: types)
+        let typeHash = SwiftKeccak.keccak256(encodedType.data(using: .utf8)!)
+
+        var encodedData = Data()
+        encodedData.append(typeHash)
+
+        for field in type.fields {
+          guard let value = data[field.name] else {
+            throw ABI.EIP712.Error.missingField(typeName: typeName, fieldName: field.name)
+          }
+
+          let encodedValue = try encodeValue(
+            value: value,
+            field: field,
+            types: types
+          )
+          encodedData.append(encodedValue)
+        }
+
+        return Hex(SwiftKeccak.keccak256(encodedData))
+      }
+
+      /// Encodes a value for the given field according to EIP-712 rules
+      static func encodeValue(
+        value: Value,
+        field: TypeDefinition.Field,
+        types: [String: TypeDefinition]
+      ) throws -> Data {
+        // Check if it's a custom type
+        if let customTypeName = field.customType {
+          // For custom types, we expect a tuple value that matches the struct
+          guard let customType = types[customTypeName] else {
+            throw ABI.EIP712.Error.missingType(customTypeName)
+          }
+
+          // Extract values from the tuple
+          guard case .tupleN(let values) = value,
+            values.count == customType.fields.count
+          else {
+            throw ABI.EIP712.Error.invalidValue(type: customTypeName, value: value)
+          }
+
+          // Build the dictionary for recursive hashing
+          var structData: [String: Value] = [:]
+          for (index, structField) in customType.fields.enumerated() {
+            structData[structField.name] = values[index]
+          }
+
+          return try hashStruct(typeName: customTypeName, data: structData, types: types).data
+        }
+
+        // Handle arrays
+        if case .array(let elementSchema, let elements) = value {
+          var encodedElements = Data()
+
+          for element in elements {
+            // Create a temporary field for the element
+            let elementField = TypeDefinition.Field(
+              name: "",
+              type: elementSchema,
+              customType: nil  // Arrays of custom types would use the schema
+            )
+            let encoded = try encodeValue(value: element, field: elementField, types: types)
+            encodedElements.append(encoded)
+          }
+
+          return SwiftKeccak.keccak256(encodedElements)
+        }
+
+        // For primitive types, handle EIP-712 specific encoding
+        switch field.type {
+        case .string:
+          guard case .string(let str) = value else {
+            throw Error.invalidValue(type: "string", value: value)
+          }
+          return SwiftKeccak.keccak256(str.data(using: .utf8)!)
+
+        case .bytes:
+          guard case .bytes(let hex) = value else {
+            throw Error.invalidValue(type: "bytes", value: value)
+          }
+          return SwiftKeccak.keccak256(hex.data)
+
+        default:
+          // For all other types (uint*, int*, address, bool, bytes*),
+          // use standard ABI encoding which produces 32-byte values
+
+          // Verify the value matches the expected schema
+          guard value.schema == field.type else {
+            throw Error.mismatchedValueType(
+              expected: field.type.canonical, actual: value.schema.canonical)
+          }
+
+          let encoded = value.encoded
+
+          // Verify we got exactly 32 bytes (all static types in EIP-712 are 32 bytes)
+          guard encoded.data.count == 32 else {
+            throw Error.invalidEncoding(
+              "Expected 32 bytes for type \(field.type.canonical), got \(encoded.data.count)")
+          }
+
+          return encoded.data
+        }
+      }
+    }
+
+    /// EIP-712 domain parameters
+    public struct Domain: Equatable, Sendable {
+      public let name: String?
+      public let version: String?
+      public let chainId: UInt?
+      public let verifyingContract: EthAddress?
+      public let salt: Hex?  // 32 bytes
+
+      public init(
+        name: String? = nil,
+        version: String? = nil,
+        chainId: UInt? = nil,
+        verifyingContract: EthAddress? = nil,
+        salt: Hex? = nil
+      ) {
+        self.name = name
+        self.version = version
+        self.chainId = chainId
+        self.verifyingContract = verifyingContract
+        if let salt = salt {
+          // Ensure salt is exactly 32 bytes
+          if salt.data.count < 32 {
+            self.salt = Hex(salt.data.leftPadded(to: 32))
+          } else if salt.data.count > 32 {
+            self.salt = Hex(salt.data.prefix(32))
+          } else {
+            self.salt = salt
+          }
+        } else {
+          self.salt = nil
+        }
+      }
+
+      /// Returns the EIP712Domain type definition based on which fields are present
+      public func domainType() -> TypeDefinition {
+        var fields: [TypeDefinition.Field] = []
+
+        if name != nil {
+          fields.append(.init(name: "name", type: .string))
+        }
+        if version != nil {
+          fields.append(.init(name: "version", type: .string))
+        }
+        if chainId != nil {
+          fields.append(.init(name: "chainId", type: .uint256))
+        }
+        if verifyingContract != nil {
+          fields.append(.init(name: "verifyingContract", type: .address))
+        }
+        if salt != nil {
+          fields.append(.init(name: "salt", type: .bytes32))
+        }
+
+        return TypeDefinition(fields: fields)
+      }
+
+      /// Convert domain to Value dictionary for hashing
+      func toValues() throws -> [String: Value] {
+        var result: [String: Value] = [:]
+
+        if let name = name {
+          result["name"] = .string(name)
+        }
+        if let version = version {
+          result["version"] = .string(version)
+        }
+        if let chainId = chainId {
+          result["chainId"] = .uint256(Number(chainId))
+        }
+        if let verifyingContract = verifyingContract {
+          result["verifyingContract"] = .address(verifyingContract)
+        }
+        if let salt = salt {
+          result["salt"] = .bytes32(salt)
+        }
+
+        return result
+      }
+    }
+
+    /// Represents a custom type definition with fields
+    public struct TypeDefinition: Equatable, Sendable {
+      public let fields: [Field]
+
+      public init(fields: [Field]) {
+        self.fields = fields
+      }
+
+      public struct Field: Equatable, Sendable {
+        public let name: String
+        public let type: Schema
+        public let customType: String?  // For referencing custom types
+
+        public init(name: String, type: Schema, customType: String? = nil) {
+          self.name = name
+          self.type = type
+          self.customType = customType
+        }
+      }
+    }
+
+    // MARK: - Type Encoding
+
+    /// Encodes the type string per EIP-712 (e.g., "Mail(Person from,Person to,string contents)")
+    public static func encodeType(
+      _ typeName: String,
+      types: [String: TypeDefinition]
+    ) throws -> String {
+      guard types[typeName] != nil else {
+        throw Error.missingType(typeName)
+      }
+
+      var result = ""
+      var processedTypes = Set<String>()
+      var typesToProcess = [typeName]
+      var referencedTypes: [String] = []
+
+      // First, encode the primary type
+      while let currentType = typesToProcess.first {
+        typesToProcess.removeFirst()
+
+        guard !processedTypes.contains(currentType) else {
+          continue
+        }
+
+        guard let typeDefinition = types[currentType] else {
+          throw Error.missingType(currentType)
+        }
+
+        // Build the type string
+        let fieldStrings = typeDefinition.fields.map { field in
+          let typeStr = field.customType ?? field.type.canonical
+          return "\(typeStr) \(field.name)"
+        }.joined(separator: ",")
+
+        let encoded = "\(currentType)(\(fieldStrings))"
+
+        if processedTypes.isEmpty {
+          // This is the primary type
+          result = encoded
+        } else {
+          // This is a referenced type, save it for later
+          referencedTypes.append(encoded)
+        }
+
+        processedTypes.insert(currentType)
+
+        // Find referenced custom types
+        for field in typeDefinition.fields {
+          if let customType = field.customType,
+            !processedTypes.contains(customType)
+          {
+            typesToProcess.append(customType)
+          }
+
+          // Also check for custom types in arrays
+          if case .array(let schema) = field.type,
+            case .tuple(_) = schema,
+            let arrayCustomType = field.customType?.replacingOccurrences(of: "[]", with: ""),
+            !processedTypes.contains(arrayCustomType)
+          {
+            typesToProcess.append(arrayCustomType)
+          }
+        }
+      }
+
+      // Sort referenced types alphabetically and append them
+      referencedTypes.sort()
+      return result + referencedTypes.joined()
+    }
+
+    // MARK: - Errors
+
+    public enum Error: Swift.Error, Equatable {
+      case invalidDomain(String)
+      case missingType(String)
+      case missingField(typeName: String, fieldName: String)
+      case invalidType(String)
+      case unsupportedType(String)
+      case encodingError(String)
+      case invalidValue(type: String, value: Value)
+      case mismatchedValueType(expected: String, actual: String)
+      case invalidEncoding(String)
+    }
+  }
+}
+
+// MARK: - Data Extension
+
+extension Data {
+  func leftPadded(to size: Int) -> Data {
+    if count >= size {
+      return self
+    }
+    let padding = Data(repeating: 0, count: size - count)
+    return padding + self
+  }
+}
+
+// MARK: - Convenience Initializers
+
+extension ABI.EIP712.TypedData {
+  /// Initialize from a JSON string
+  public init(jsonString: String) throws {
+    let data = jsonString.data(using: .utf8)!
+    try self.init(jsonData: data)
+  }
+
+  /// Initialize from JSON data
+  public init(jsonData: Data) throws {
+    let decoder = JSONDecoder()
+    let decoded = try decoder.decode(CodableTypedData.self, from: jsonData)
+
+    self.domain = decoded.domain
+    self.primaryType = decoded.primaryType
+
+    // Parse types from JSON representation
+    self.types = try decoded.types.mapValues { jsonFields in
+      let fields = try jsonFields.map { jsonField in
+        try ABI.EIP712.TypeDefinition.Field(fromJSON: jsonField)
+      }
+      return ABI.EIP712.TypeDefinition(fields: fields)
+    }
+
+    // Convert the message based on the primary type
+    guard let primaryTypeDef = types[primaryType] else {
+      throw ABI.EIP712.Error.missingType(primaryType)
+    }
+
+    self.message = try Self.decodeMessage(
+      decoded.message,
+      typeDefinition: primaryTypeDef,
+      types: types
+    )
+  }
+
+  /// Convert to JSON data
+  public func jsonData() throws -> Data {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+    // Convert types to JSON representation
+    let jsonTypes = types.mapValues { typeDef in
+      typeDef.fields.map { $0.toJSON() }
+    }
+
+    let codable = try CodableTypedData(
+      domain: domain,
+      types: jsonTypes,
+      primaryType: primaryType,
+      message: Self.encodeMessage(message, typeDefinition: types[primaryType]!, types: types)
+    )
+
+    return try encoder.encode(codable)
+  }
+
+  /// Convert to JSON string
+  public func jsonString() throws -> String {
+    String(data: try jsonData(), encoding: .utf8)!
+  }
+}
+
+// MARK: - JSON Field Representation
+
+private struct JSONField: Codable {
+  let name: String
+  let type: String
+}
+
+// MARK: - TypeDefinition.Field JSON Conversion
+
+extension ABI.EIP712.TypeDefinition.Field {
+  fileprivate init(fromJSON json: JSONField) throws {
+    self.name = json.name
+
+    // Parse the type string using the new Schema.fromCanonical
+    let (schema, customType) = try ABI.Schema.fromCanonical(json.type)
+    self.type = schema
+    self.customType = customType
+  }
+
+  fileprivate func toJSON() -> JSONField {
+    let typeString = customType ?? type.canonical
+    return JSONField(name: name, type: typeString)
+  }
+}
+
+// MARK: - Private Codable Wrapper
+
+private struct CodableTypedData: Codable {
+  let domain: ABI.EIP712.Domain
+  let types: [String: [JSONField]]
+  let primaryType: String
+  let message: [String: Any?]
+
+  enum CodingKeys: String, CodingKey {
+    case domain, types, primaryType, message
+  }
+
+  init(
+    domain: ABI.EIP712.Domain, types: [String: [JSONField]], primaryType: String,
+    message: [String: Any?]
+  ) {
+    self.domain = domain
+    self.types = types
+    self.primaryType = primaryType
+    self.message = message
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    self.domain = try container.decode(ABI.EIP712.Domain.self, forKey: .domain)
+    self.types = try container.decode([String: [JSONField]].self, forKey: .types)
+    self.primaryType = try container.decode(String.self, forKey: .primaryType)
+
+    // Decode message as generic JSON
+    let messageData = try container.decode(JSONValue.self, forKey: .message)
+    guard let dict = messageData.objectValue else {
+      throw DecodingError.dataCorruptedError(
+        forKey: .message, in: container, debugDescription: "Message must be an object")
+    }
+    self.message = dict.mapValues { $0.value }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encode(domain, forKey: .domain)
+    try container.encode(types, forKey: .types)
+    try container.encode(primaryType, forKey: .primaryType)
+    try container.encode(JSONValue(message), forKey: .message)
+  }
+}
+
+// MARK: - Message Conversion Helpers
+
+extension ABI.EIP712.TypedData {
+  fileprivate static func decodeMessage(
+    _ dict: [String: Any?],
+    typeDefinition: ABI.EIP712.TypeDefinition,
+    types: [String: ABI.EIP712.TypeDefinition]
+  ) throws -> [String: ABI.Value] {
+    var result: [String: ABI.Value] = [:]
+
+    for field in typeDefinition.fields {
+      guard let value = dict[field.name] else {
+        throw ABI.EIP712.Error.missingField(typeName: "message", fieldName: field.name)
+      }
+
+      result[field.name] = try decodeValue(value, field: field, types: types)
+    }
+
+    return result
+  }
+
+  fileprivate static func encodeMessage(
+    _ values: [String: ABI.Value],
+    typeDefinition: ABI.EIP712.TypeDefinition,
+    types: [String: ABI.EIP712.TypeDefinition]
+  ) throws -> [String: Any?] {
+    var result: [String: Any?] = [:]
+
+    for field in typeDefinition.fields {
+      guard let value = values[field.name] else {
+        throw ABI.EIP712.Error.missingField(typeName: "message", fieldName: field.name)
+      }
+
+      result[field.name] = try encodeValueToJSON(value, field: field, types: types)
+    }
+
+    return result
+  }
+
+  fileprivate static func decodeValue(
+    _ value: Any?, field: ABI.EIP712.TypeDefinition.Field,
+    types: [String: ABI.EIP712.TypeDefinition]
+  ) throws -> ABI.Value {
+    // Check if it's a custom type
+    if let customTypeName = field.customType {
+      // Handle arrays of custom types
+      if customTypeName.hasSuffix("[]") {
+        let elementTypeName = String(customTypeName.dropLast(2))
+        guard let array = value as? [Any?],
+          let elementType = types[elementTypeName]
+        else {
+          throw ABI.EIP712.Error.invalidValue(
+            type: customTypeName, value: .string("\(value ?? "nil")"))
+        }
+
+        let elements = try array.map { element in
+          try decodeCustomTypeValue(
+            element, typeName: elementTypeName, typeDefinition: elementType, types: types)
+        }
+
+        // Return array with tuple schema (placeholder for custom types)
+        return .array(.tuple([]), elements)
+      } else {
+        // Regular custom type
+        guard let customType = types[customTypeName] else {
+          throw ABI.EIP712.Error.missingType(customTypeName)
+        }
+        return try decodeCustomTypeValue(
+          value, typeName: customTypeName, typeDefinition: customType, types: types)
+      }
+    }
+
+    // Handle arrays of primitive types
+    if case .array(let elementSchema) = field.type {
+      guard let array = value as? [Any?] else {
+        throw ABI.EIP712.Error.invalidValue(
+          type: field.type.canonical, value: .string("\(value ?? "nil")"))
+      }
+
+      let elements = try array.map { element in
+        try decodeBasicValue(element, schema: elementSchema)
+      }
+
+      return .array(elementSchema, elements)
+    }
+
+    // Handle primitive types
+    return try decodeBasicValue(value, schema: field.type)
+  }
+
+  fileprivate static func decodeCustomTypeValue(
+    _ value: Any?, typeName: String, typeDefinition: ABI.EIP712.TypeDefinition,
+    types: [String: ABI.EIP712.TypeDefinition]
+  ) throws -> ABI.Value {
+    guard let dict = value as? [String: Any?] else {
+      throw ABI.EIP712.Error.invalidValue(type: typeName, value: .string("\(value ?? "nil")"))
+    }
+
+    var values: [ABI.Value] = []
+    for field in typeDefinition.fields {
+      guard let fieldValue = dict[field.name] else {
+        throw ABI.EIP712.Error.missingField(typeName: typeName, fieldName: field.name)
+      }
+      values.append(try decodeValue(fieldValue, field: field, types: types))
+    }
+    return .tupleN(values)
+  }
+
+  fileprivate static func encodeValueToJSON(
+    _ value: ABI.Value, field: ABI.EIP712.TypeDefinition.Field,
+    types: [String: ABI.EIP712.TypeDefinition]
+  ) throws -> Any? {
+    // Check if it's a custom type
+    if let customTypeName = field.customType {
+      // Handle arrays of custom types
+      if customTypeName.hasSuffix("[]") {
+        let elementTypeName = String(customTypeName.dropLast(2))
+        guard case .array(_, let elements) = value,
+          let elementType = types[elementTypeName]
+        else {
+          throw ABI.EIP712.Error.invalidValue(type: customTypeName, value: value)
+        }
+
+        return try elements.map { element in
+          try encodeCustomTypeToJSON(
+            element, typeName: elementTypeName, typeDefinition: elementType, types: types)
+        }
+      } else {
+        // Regular custom type
+        guard let customType = types[customTypeName] else {
+          throw ABI.EIP712.Error.missingType(customTypeName)
+        }
+        return try encodeCustomTypeToJSON(
+          value, typeName: customTypeName, typeDefinition: customType, types: types)
+      }
+    }
+
+    // Handle arrays
+    if case .array(_, let elements) = value {
+      return try elements.map { element in
+        try encodeBasicValueToJSON(element)
+      }
+    }
+
+    // Handle primitive types
+    return try encodeBasicValueToJSON(value)
+  }
+
+  fileprivate static func encodeCustomTypeToJSON(
+    _ value: ABI.Value, typeName: String, typeDefinition: ABI.EIP712.TypeDefinition,
+    types: [String: ABI.EIP712.TypeDefinition]
+  ) throws -> Any? {
+    guard case .tupleN(let values) = value else {
+      throw ABI.EIP712.Error.invalidValue(type: typeName, value: value)
+    }
+
+    var dict: [String: Any?] = [:]
+    for (index, field) in typeDefinition.fields.enumerated() {
+      guard index < values.count else {
+        throw ABI.EIP712.Error.invalidValue(type: typeName, value: value)
+      }
+      dict[field.name] = try encodeValueToJSON(values[index], field: field, types: types)
+    }
+    return dict
+  }
+
+  fileprivate static func decodeBasicValue(_ value: Any?, schema: ABI.Schema) throws -> ABI.Value {
+    guard let value = value else {
+      throw ABI.EIP712.Error.invalidValue(type: schema.canonical, value: .string("nil"))
+    }
+
+    return try createValueFromJSON(value, schema: schema)
+  }
+
+  /// Helper method to create ABI.Value from JSON values based on schema
+  fileprivate static func createValueFromJSON(_ jsonValue: Any, schema: ABI.Schema) throws
+    -> ABI.Value
+  {
+    switch schema {
+    case .address:
+      guard let str = jsonValue as? String else {
+        throw ABI.EIP712.Error.invalidValue(type: schema.canonical, value: .string("\(jsonValue)"))
+      }
+      let address = EthAddress(fromHexString: str)
+      guard address != nil else {
+        throw ABI.EIP712.Error.invalidValue(type: schema.canonical, value: .string("\(jsonValue)"))
+      }
+      return .address(address!)
+
+    case .string:
+      guard let str = jsonValue as? String else {
+        throw ABI.EIP712.Error.invalidValue(type: schema.canonical, value: .string("\(jsonValue)"))
+      }
+      return .string(str)
+
+    case .bytes:
+      guard let str = jsonValue as? String else {
+        throw ABI.EIP712.Error.invalidValue(type: schema.canonical, value: .string("\(jsonValue)"))
+      }
+      guard let hex = Hex(hex: str) else {
+        throw ABI.EIP712.Error.invalidValue(type: schema.canonical, value: .string("\(jsonValue)"))
+      }
+      return .bytes(hex)
+
+    case .bool:
+      guard let bool = jsonValue as? Bool else {
+        throw ABI.EIP712.Error.invalidValue(type: schema.canonical, value: .string("\(jsonValue)"))
+      }
+      return .bool(bool)
+
+    // Handle all integer types through helpers
+    case _ where schema.canonical.starts(with: "uint"):
+      return try createUIntValue(from: jsonValue, schema: schema)
+
+    case _ where schema.canonical.starts(with: "int"):
+      return try createIntValue(from: jsonValue, schema: schema)
+
+    case _ where schema.canonical.starts(with: "bytes") && schema != .bytes:
+      return try createBytesNValue(from: jsonValue, schema: schema)
+
+    default:
+      throw ABI.EIP712.Error.unsupportedType(schema.canonical)
+    }
+  }
+
+  /// Create uint value from JSON
+  fileprivate static func createUIntValue(from jsonValue: Any, schema: ABI.Schema) throws
+    -> ABI.Value
+  {
+    // First, extract the numeric value
+    let number: Number
+    if let u = jsonValue as? UInt {
+      number = Number(u)
+    } else if let i = jsonValue as? Int, i >= 0 {
+      number = Number(i)
+    } else if let d = jsonValue as? Double, d >= 0 {
+      number = Number(Int(d))
+    } else if let s = jsonValue as? String, let n = Number(s) {
+      number = n
+    } else {
+      throw ABI.EIP712.Error.invalidValue(type: schema.canonical, value: .string("\(jsonValue)"))
+    }
+
+    // For small types that fit in UInt, check if we can use the more efficient representation
+    switch schema {
+    case .uint8, .uint16, .uint24, .uint32:
+      if let uint = number.uInt {
+        switch schema {
+        case .uint8: return .uint8(uint)
+        case .uint16: return .uint16(uint)
+        case .uint24: return .uint24(uint)
+        case .uint32: return .uint32(uint)
+        default: break
+        }
+      }
+    default:
+      break
+    }
+
+    // For all uint types, create with Number
+    switch schema {
+    case .uint8: return .uint8(UInt(number))
+    case .uint16: return .uint16(UInt(number))
+    case .uint24: return .uint24(UInt(number))
+    case .uint32: return .uint32(UInt(number))
+    case .uint40: return .uint40(number)
+    case .uint48: return .uint48(number)
+    case .uint56: return .uint56(number)
+    case .uint64: return .uint64(number)
+    case .uint72: return .uint72(number)
+    case .uint80: return .uint80(number)
+    case .uint88: return .uint88(number)
+    case .uint96: return .uint96(number)
+    case .uint104: return .uint104(number)
+    case .uint112: return .uint112(number)
+    case .uint120: return .uint120(number)
+    case .uint128: return .uint128(number)
+    case .uint136: return .uint136(number)
+    case .uint144: return .uint144(number)
+    case .uint152: return .uint152(number)
+    case .uint160: return .uint160(number)
+    case .uint168: return .uint168(number)
+    case .uint176: return .uint176(number)
+    case .uint184: return .uint184(number)
+    case .uint192: return .uint192(number)
+    case .uint200: return .uint200(number)
+    case .uint208: return .uint208(number)
+    case .uint216: return .uint216(number)
+    case .uint224: return .uint224(number)
+    case .uint232: return .uint232(number)
+    case .uint240: return .uint240(number)
+    case .uint248: return .uint248(number)
+    case .uint256: return .uint256(number)
+    default:
+      throw ABI.EIP712.Error.unsupportedType(schema.canonical)
+    }
+  }
+
+  /// Create int value from JSON
+  fileprivate static func createIntValue(from jsonValue: Any, schema: ABI.Schema) throws
+    -> ABI.Value
+  {
+    // First, extract the numeric value
+    let snumber: SNumber
+    if let i = jsonValue as? Int {
+      snumber = SNumber(i)
+    } else if let d = jsonValue as? Double {
+      snumber = SNumber(Int(d))
+    } else if let s = jsonValue as? String, let n = SNumber(s) {
+      snumber = n
+    } else {
+      throw ABI.EIP712.Error.invalidValue(type: schema.canonical, value: .string("\(jsonValue)"))
+    }
+
+    // For small types that fit in Int, check if we can use the more efficient representation
+    switch schema {
+    case .int8, .int16, .int24, .int32:
+      if let int = snumber.int {
+        switch schema {
+        case .int8: return .int8(int)
+        case .int16: return .int16(int)
+        case .int24: return .int24(int)
+        case .int32: return .int32(int)
+        default: break
+        }
+      }
+    default:
+      break
+    }
+
+    // For all int types, create with SNumber
+    switch schema {
+    case .int8: return .int8(Int(snumber))
+    case .int16: return .int16(Int(snumber))
+    case .int24: return .int24(Int(snumber))
+    case .int32: return .int32(Int(snumber))
+    case .int40: return .int40(snumber)
+    case .int48: return .int48(snumber)
+    case .int56: return .int56(snumber)
+    case .int64: return .int64(snumber)
+    case .int72: return .int72(snumber)
+    case .int80: return .int80(snumber)
+    case .int88: return .int88(snumber)
+    case .int96: return .int96(snumber)
+    case .int104: return .int104(snumber)
+    case .int112: return .int112(snumber)
+    case .int120: return .int120(snumber)
+    case .int128: return .int128(snumber)
+    case .int136: return .int136(snumber)
+    case .int144: return .int144(snumber)
+    case .int152: return .int152(snumber)
+    case .int160: return .int160(snumber)
+    case .int168: return .int168(snumber)
+    case .int176: return .int176(snumber)
+    case .int184: return .int184(snumber)
+    case .int192: return .int192(snumber)
+    case .int200: return .int200(snumber)
+    case .int208: return .int208(snumber)
+    case .int216: return .int216(snumber)
+    case .int224: return .int224(snumber)
+    case .int232: return .int232(snumber)
+    case .int240: return .int240(snumber)
+    case .int248: return .int248(snumber)
+    case .int256: return .int256(snumber)
+    default:
+      throw ABI.EIP712.Error.unsupportedType(schema.canonical)
+    }
+  }
+
+  /// Create bytesN value from JSON
+  fileprivate static func createBytesNValue(from jsonValue: Any, schema: ABI.Schema) throws
+    -> ABI.Value
+  {
+    guard let str = jsonValue as? String else {
+      throw ABI.EIP712.Error.invalidValue(type: schema.canonical, value: .string("\(jsonValue)"))
+    }
+
+    guard let hex = Hex(hex: str) else {
+      throw ABI.EIP712.Error.invalidValue(type: schema.canonical, value: .string(str))
+    }
+
+    // Extract size from schema - we know it matches bytesN pattern
+    let canonical = schema.canonical
+    guard canonical.starts(with: "bytes"),
+      let size = Int(canonical.dropFirst(5)),
+      size > 0, size <= 32
+    else {
+      throw ABI.EIP712.Error.unsupportedType(canonical)
+    }
+
+    let paddedHex = Hex(hex.data.leftPadded(to: size))
+
+    // Map size to the appropriate case
+    switch size {
+    case 1: return .bytes1(paddedHex)
+    case 2: return .bytes2(paddedHex)
+    case 3: return .bytes3(paddedHex)
+    case 4: return .bytes4(paddedHex)
+    case 5: return .bytes5(paddedHex)
+    case 6: return .bytes6(paddedHex)
+    case 7: return .bytes7(paddedHex)
+    case 8: return .bytes8(paddedHex)
+    case 9: return .bytes9(paddedHex)
+    case 10: return .bytes10(paddedHex)
+    case 11: return .bytes11(paddedHex)
+    case 12: return .bytes12(paddedHex)
+    case 13: return .bytes13(paddedHex)
+    case 14: return .bytes14(paddedHex)
+    case 15: return .bytes15(paddedHex)
+    case 16: return .bytes16(paddedHex)
+    case 17: return .bytes17(paddedHex)
+    case 18: return .bytes18(paddedHex)
+    case 19: return .bytes19(paddedHex)
+    case 20: return .bytes20(paddedHex)
+    case 21: return .bytes21(paddedHex)
+    case 22: return .bytes22(paddedHex)
+    case 23: return .bytes23(paddedHex)
+    case 24: return .bytes24(paddedHex)
+    case 25: return .bytes25(paddedHex)
+    case 26: return .bytes26(paddedHex)
+    case 27: return .bytes27(paddedHex)
+    case 28: return .bytes28(paddedHex)
+    case 29: return .bytes29(paddedHex)
+    case 30: return .bytes30(paddedHex)
+    case 31: return .bytes31(paddedHex)
+    case 32: return .bytes32(paddedHex)
+    default:
+      throw ABI.EIP712.Error.unsupportedType(canonical)
+    }
+  }
+
+  fileprivate static func encodeBasicValueToJSON(_ value: ABI.Value) throws -> Any? {
+    switch value {
+    case .address(let addr):
+      return addr.hex
+    case .string(let str):
+      return str
+    case .bytes(let hex):
+      return hex.hex
+    case .bool(let b):
+      return b
+    case let v where v.asUInt != nil:
+      return v.asUInt!
+    case let v where v.asNumber != nil:
+      let num = v.asNumber!
+      // Use the computed property from Number
+      if let uint = num.uInt {
+        return uint
+      } else {
+        // For large numbers, return as string to avoid JSON precision issues
+        return num.description
+      }
+    case let v where v.asInt != nil:
+      return v.asInt!
+    case let v where v.asSNumber != nil:
+      let snum = v.asSNumber!
+      // Use the computed property from SNumber
+      if let int = snum.int {
+        return int
+      } else {
+        // For large numbers, return as string to avoid JSON precision issues
+        return snum.description
+      }
+    case let v where v.asHex != nil:
+      return v.asHex!.hex
+    default:
+      throw ABI.EIP712.Error.invalidValue(type: value.schema.canonical, value: value)
+    }
+  }
+}
+
+// MARK: - Domain Codable
+
+extension ABI.EIP712.Domain: Codable {
+  enum CodingKeys: String, CodingKey {
+    case name, version, chainId, verifyingContract, salt
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    self.name = try container.decodeIfPresent(String.self, forKey: .name)
+    self.version = try container.decodeIfPresent(String.self, forKey: .version)
+    self.chainId = try container.decodeIfPresent(UInt.self, forKey: .chainId)
+
+    if let contractStr = try container.decodeIfPresent(String.self, forKey: .verifyingContract) {
+      self.verifyingContract = EthAddress(fromHexString: contractStr)
+    } else {
+      self.verifyingContract = nil
+    }
+
+    if let saltStr = try container.decodeIfPresent(String.self, forKey: .salt) {
+      self.salt = Hex(hex: saltStr)
+    } else {
+      self.salt = nil
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encodeIfPresent(name, forKey: .name)
+    try container.encodeIfPresent(version, forKey: .version)
+    try container.encodeIfPresent(chainId, forKey: .chainId)
+    try container.encodeIfPresent(verifyingContract?.hex, forKey: .verifyingContract)
+    try container.encodeIfPresent(salt?.hex, forKey: .salt)
+  }
+}
+
+// MARK: - TypeDefinition Codable
+
+extension ABI.EIP712.TypeDefinition: Codable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    self.fields = try container.decode([Field].self)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(fields)
+  }
+}
+
+extension ABI.EIP712.TypeDefinition.Field: Codable {
+  enum CodingKeys: String, CodingKey {
+    case name, type
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    self.name = try container.decode(String.self, forKey: .name)
+    let typeString = try container.decode(String.self, forKey: .type)
+
+    let (schema, customType) = try ABI.Schema.fromCanonical(typeString)
+    self.type = schema
+    self.customType = customType
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encode(name, forKey: .name)
+
+    // Encode the canonical type string
+    if let customType = customType {
+      try container.encode(customType, forKey: .type)
+    } else {
+      try container.encode(type.canonical, forKey: .type)
+    }
+  }
+}

--- a/Sources/Eth/ABI/Schema+Decode.swift
+++ b/Sources/Eth/ABI/Schema+Decode.swift
@@ -1,0 +1,212 @@
+//
+//  Schema+Decode.swift
+//  Eth
+//
+//  Extensions for decoding ABI.Schema from canonical string representations
+//
+
+import Foundation
+
+extension ABI.Schema {
+  /// Parse a canonical type string into an ABI.Schema
+  /// - Parameter canonical: The canonical type string (e.g., "uint256", "address", "bytes32[]")
+  /// - Returns: The corresponding ABI.Schema
+  /// - Throws: ABI.EIP712.Error if the type cannot be parsed
+  public static func fromCanonical(_ canonical: String) throws -> (
+    schema: ABI.Schema, customType: String?
+  ) {
+    // Check if it's an array type
+    if canonical.hasSuffix("[]") {
+      let elementType = String(canonical.dropLast(2))
+      let (elementSchema, elementCustom) = try fromCanonical(elementType)
+
+      // For arrays of custom types, we return a placeholder schema
+      if elementCustom != nil {
+        return (.array(.tuple([])), canonical)  // Store full array type name
+      } else {
+        return (.array(elementSchema), nil)
+      }
+    }
+
+    // Check for fixed-size arrays (e.g., "uint256[3]")
+    if let bracketIndex = canonical.lastIndex(of: "["),
+      let closeBracketIndex = canonical.lastIndex(of: "]"),
+      bracketIndex < closeBracketIndex
+    {
+      let elementType = String(canonical[..<bracketIndex])
+      let sizeStr = String(canonical[canonical.index(after: bracketIndex)..<closeBracketIndex])
+
+      guard let size = Int(sizeStr), size > 0 else {
+        throw ABI.EIP712.Error.unsupportedType(canonical)
+      }
+
+      let (elementSchema, elementCustom) = try fromCanonical(elementType)
+
+      // For fixed arrays of custom types
+      if elementCustom != nil {
+        return (.arrayN(.tuple([]), size), canonical)
+      } else {
+        return (.arrayN(elementSchema, size), nil)
+      }
+    }
+
+    // Try to parse as a primitive type
+    switch canonical {
+    case "address": return (.address, nil)
+    case "bool": return (.bool, nil)
+    case "string": return (.string, nil)
+    case "bytes": return (.bytes, nil)
+
+    case let t where t.starts(with: "uint"):
+      let bits = String(t.dropFirst(4))
+      guard let size = Int(bits), size > 0, size <= 256, size % 8 == 0 else {
+        // Not a valid uint type, must be custom
+        return (.tuple([]), canonical)
+      }
+
+      let schema: ABI.Schema = try uintSchema(bits: size)
+      return (schema, nil)
+
+    case let t where t.starts(with: "int"):
+      let bits = String(t.dropFirst(3))
+      guard let size = Int(bits), size > 0, size <= 256, size % 8 == 0 else {
+        // Not a valid int type, must be custom
+        return (.tuple([]), canonical)
+      }
+
+      let schema: ABI.Schema = try intSchema(bits: size)
+      return (schema, nil)
+
+    case let t where t.starts(with: "bytes") && t.count > 5:
+      let sizeStr = String(t.dropFirst(5))
+      guard let size = Int(sizeStr), size > 0, size <= 32 else {
+        // Not a valid bytes type, must be custom
+        return (.tuple([]), canonical)
+      }
+
+      let schema: ABI.Schema = try bytesNSchema(size: size)
+      return (schema, nil)
+
+    default:
+      // It's a custom type - use tuple as a placeholder
+      return (.tuple([]), canonical)
+    }
+  }
+
+  /// Get the uint schema for a given bit size
+  private static func uintSchema(bits: Int) throws -> ABI.Schema {
+    switch bits {
+    case 8: return .uint8
+    case 16: return .uint16
+    case 24: return .uint24
+    case 32: return .uint32
+    case 40: return .uint40
+    case 48: return .uint48
+    case 56: return .uint56
+    case 64: return .uint64
+    case 72: return .uint72
+    case 80: return .uint80
+    case 88: return .uint88
+    case 96: return .uint96
+    case 104: return .uint104
+    case 112: return .uint112
+    case 120: return .uint120
+    case 128: return .uint128
+    case 136: return .uint136
+    case 144: return .uint144
+    case 152: return .uint152
+    case 160: return .uint160
+    case 168: return .uint168
+    case 176: return .uint176
+    case 184: return .uint184
+    case 192: return .uint192
+    case 200: return .uint200
+    case 208: return .uint208
+    case 216: return .uint216
+    case 224: return .uint224
+    case 232: return .uint232
+    case 240: return .uint240
+    case 248: return .uint248
+    case 256: return .uint256
+    default: throw ABI.EIP712.Error.unsupportedType("uint\(bits)")
+    }
+  }
+
+  /// Get the int schema for a given bit size
+  private static func intSchema(bits: Int) throws -> ABI.Schema {
+    switch bits {
+    case 8: return .int8
+    case 16: return .int16
+    case 24: return .int24
+    case 32: return .int32
+    case 40: return .int40
+    case 48: return .int48
+    case 56: return .int56
+    case 64: return .int64
+    case 72: return .int72
+    case 80: return .int80
+    case 88: return .int88
+    case 96: return .int96
+    case 104: return .int104
+    case 112: return .int112
+    case 120: return .int120
+    case 128: return .int128
+    case 136: return .int136
+    case 144: return .int144
+    case 152: return .int152
+    case 160: return .int160
+    case 168: return .int168
+    case 176: return .int176
+    case 184: return .int184
+    case 192: return .int192
+    case 200: return .int200
+    case 208: return .int208
+    case 216: return .int216
+    case 224: return .int224
+    case 232: return .int232
+    case 240: return .int240
+    case 248: return .int248
+    case 256: return .int256
+    default: throw ABI.EIP712.Error.unsupportedType("int\(bits)")
+    }
+  }
+
+  /// Get the bytesN schema for a given size
+  private static func bytesNSchema(size: Int) throws -> ABI.Schema {
+    switch size {
+    case 1: return .bytes1
+    case 2: return .bytes2
+    case 3: return .bytes3
+    case 4: return .bytes4
+    case 5: return .bytes5
+    case 6: return .bytes6
+    case 7: return .bytes7
+    case 8: return .bytes8
+    case 9: return .bytes9
+    case 10: return .bytes10
+    case 11: return .bytes11
+    case 12: return .bytes12
+    case 13: return .bytes13
+    case 14: return .bytes14
+    case 15: return .bytes15
+    case 16: return .bytes16
+    case 17: return .bytes17
+    case 18: return .bytes18
+    case 19: return .bytes19
+    case 20: return .bytes20
+    case 21: return .bytes21
+    case 22: return .bytes22
+    case 23: return .bytes23
+    case 24: return .bytes24
+    case 25: return .bytes25
+    case 26: return .bytes26
+    case 27: return .bytes27
+    case 28: return .bytes28
+    case 29: return .bytes29
+    case 30: return .bytes30
+    case 31: return .bytes31
+    case 32: return .bytes32
+    default: throw ABI.EIP712.Error.unsupportedType("bytes\(size)")
+    }
+  }
+}

--- a/Sources/Eth/JSONValue.swift
+++ b/Sources/Eth/JSONValue.swift
@@ -1,0 +1,201 @@
+//
+//  JSONValue.swift
+//  Eth
+//
+//  A type-safe representation of JSON values
+//
+
+import Foundation
+
+/// A type-safe representation of JSON values
+public enum JSONValue: Codable, Equatable, Sendable {
+  case string(String)
+  case number(Double)
+  case bool(Bool)
+  case array([JSONValue])
+  case object([String: JSONValue])
+  case null
+
+  /// Initialize from any value, attempting to convert it to the appropriate JSON type
+  public init(_ value: Any?) {
+    guard let value = value else {
+      self = .null
+      return
+    }
+
+    switch value {
+    case let str as String:
+      self = .string(str)
+    case let num as Double:
+      self = .number(num)
+    case let num as Float:
+      self = .number(Double(num))
+    case let num as Int:
+      self = .number(Double(num))
+    case let num as UInt:
+      self = .number(Double(num))
+    case let num as Int8:
+      self = .number(Double(num))
+    case let num as UInt8:
+      self = .number(Double(num))
+    case let num as Int16:
+      self = .number(Double(num))
+    case let num as UInt16:
+      self = .number(Double(num))
+    case let num as Int32:
+      self = .number(Double(num))
+    case let num as UInt32:
+      self = .number(Double(num))
+    case let num as Int64:
+      self = .number(Double(num))
+    case let num as UInt64:
+      self = .number(Double(num))
+    case let bool as Bool:
+      self = .bool(bool)
+    case let array as [Any]:
+      self = .array(array.map { JSONValue($0) })
+    case let array as [Any?]:
+      self = .array(array.map { JSONValue($0) })
+    case let dict as [String: Any]:
+      self = .object(dict.mapValues { JSONValue($0) })
+    case let dict as [String: Any?]:
+      self = .object(dict.mapValues { JSONValue($0) })
+    case is NSNull:
+      self = .null
+    default:
+      // For unknown types, convert to string representation
+      self = .string("\(value)")
+    }
+  }
+
+  /// Get the underlying value as `Any?`
+  public var value: Any? {
+    switch self {
+    case .string(let str): return str
+    case .number(let num): return num
+    case .bool(let bool): return bool
+    case .array(let arr): return arr.map { $0.value }
+    case .object(let obj): return obj.mapValues { $0.value }
+    case .null: return nil
+    }
+  }
+
+  // MARK: - Codable
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+
+    if container.decodeNil() {
+      self = .null
+    } else if let bool = try? container.decode(Bool.self) {
+      self = .bool(bool)
+    } else if let number = try? container.decode(Double.self) {
+      self = .number(number)
+    } else if let string = try? container.decode(String.self) {
+      self = .string(string)
+    } else if let array = try? container.decode([JSONValue].self) {
+      self = .array(array)
+    } else if let object = try? container.decode([String: JSONValue].self) {
+      self = .object(object)
+    } else {
+      throw DecodingError.dataCorruptedError(
+        in: container,
+        debugDescription: "Could not decode JSONValue"
+      )
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+
+    switch self {
+    case .null:
+      try container.encodeNil()
+    case .bool(let value):
+      try container.encode(value)
+    case .number(let value):
+      try container.encode(value)
+    case .string(let value):
+      try container.encode(value)
+    case .array(let array):
+      try container.encode(array)
+    case .object(let object):
+      try container.encode(object)
+    }
+  }
+
+  // MARK: - Convenience Accessors
+
+  /// Returns the value as a String if it is a string, otherwise nil
+  public var stringValue: String? {
+    guard case .string(let value) = self else { return nil }
+    return value
+  }
+
+  /// Returns the value as a Double if it is a number, otherwise nil
+  public var numberValue: Double? {
+    guard case .number(let value) = self else { return nil }
+    return value
+  }
+
+  /// Returns the value as an Int if it is a number that can be exactly represented as Int, otherwise nil
+  public var intValue: Int? {
+    guard case .number(let value) = self else { return nil }
+    let int = Int(value)
+    // Check if conversion is lossless
+    guard Double(int) == value else { return nil }
+    return int
+  }
+
+  /// Returns the value as a UInt if it is a number that can be exactly represented as UInt, otherwise nil
+  public var uintValue: UInt? {
+    guard case .number(let value) = self,
+      value >= 0
+    else { return nil }
+    let uint = UInt(value)
+    // Check if conversion is lossless
+    guard Double(uint) == value else { return nil }
+    return uint
+  }
+
+  /// Returns the value as a Bool if it is a boolean, otherwise nil
+  public var boolValue: Bool? {
+    guard case .bool(let value) = self else { return nil }
+    return value
+  }
+
+  /// Returns the value as an array if it is an array, otherwise nil
+  public var arrayValue: [JSONValue]? {
+    guard case .array(let value) = self else { return nil }
+    return value
+  }
+
+  /// Returns the value as an object if it is an object, otherwise nil
+  public var objectValue: [String: JSONValue]? {
+    guard case .object(let value) = self else { return nil }
+    return value
+  }
+
+  /// Returns true if this is null
+  public var isNull: Bool {
+    guard case .null = self else { return false }
+    return true
+  }
+
+  // MARK: - Subscript Support
+
+  /// Access array elements by index
+  public subscript(index: Int) -> JSONValue? {
+    guard case .array(let arr) = self,
+      index >= 0,
+      index < arr.count
+    else { return nil }
+    return arr[index]
+  }
+
+  /// Access object values by key
+  public subscript(key: String) -> JSONValue? {
+    guard case .object(let obj) = self else { return nil }
+    return obj[key]
+  }
+}

--- a/Tests/EthTests/EIP712Tests.swift
+++ b/Tests/EthTests/EIP712Tests.swift
@@ -1,0 +1,679 @@
+//
+//  EIP712Tests.swift
+//  EthTests
+//
+//  Tests for EIP-712 typed data encoding and hashing
+//
+
+import SwiftKeccak
+import SwiftNumber
+import Testing
+
+@testable import Eth
+
+@Suite("EIP-712 Tests")
+struct EIP712Tests {
+
+  // MARK: - Type Encoding Tests
+
+  @Test("Encode type with nested dependencies")
+  func encodeType() throws {
+    let types: [String: ABI.EIP712.TypeDefinition] = [
+      "Mail": .init(fields: [
+        .init(name: "from", type: .tuple([]), customType: "Person"),
+        .init(name: "to", type: .tuple([]), customType: "Person"),
+        .init(name: "contents", type: .string),
+      ]),
+      "Person": .init(fields: [
+        .init(name: "name", type: .string),
+        .init(name: "wallet", type: .address),
+      ]),
+    ]
+
+    let encoded = try ABI.EIP712.encodeType("Mail", types: types)
+    #expect(
+      encoded == "Mail(Person from,Person to,string contents)Person(string name,address wallet)")
+  }
+
+  // MARK: - Hash Struct Tests
+
+  @Test("Hash struct with nested custom types")
+  func hashStruct() throws {
+    let types: [String: ABI.EIP712.TypeDefinition] = [
+      "Mail": .init(fields: [
+        .init(name: "from", type: .tuple([]), customType: "Person"),
+        .init(name: "to", type: .tuple([]), customType: "Person"),
+        .init(name: "contents", type: .string),
+      ]),
+      "Person": .init(fields: [
+        .init(name: "name", type: .string),
+        .init(name: "wallet", type: .address),
+      ]),
+    ]
+
+    let value: [String: ABI.Value] = [
+      "contents": .string("Hello, Bob!"),
+      "from": .tupleN([
+        .string("Cow"),
+        .address(try EthAddress("0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826")),
+      ]),
+      "to": .tupleN([
+        .string("Bob"),
+        .address(try EthAddress("0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB")),
+      ]),
+    ]
+
+    let hash = try ABI.EIP712.TypedData.hashStruct(typeName: "Mail", data: value, types: types)
+    #expect(hash.hex == "0xc52c0ee5d84264471806290a3f2c4cecfc5490626bf912d01f240d7a274b371e")
+  }
+
+  // MARK: - Domain Separator Tests
+
+  @Test("Domain separator with all fields")
+  func domainSeparator() throws {
+    let domain = ABI.EIP712.Domain(
+      name: "Ether Mail",
+      version: "1",
+      chainId: 1,
+      verifyingContract: try EthAddress("0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC")
+    )
+
+    let types: [String: ABI.EIP712.TypeDefinition] = [
+      "Mail": .init(fields: [
+        .init(name: "from", type: .tuple([]), customType: "Person"),
+        .init(name: "to", type: .tuple([]), customType: "Person"),
+        .init(name: "contents", type: .string),
+      ]),
+      "Person": .init(fields: [
+        .init(name: "name", type: .string),
+        .init(name: "wallet", type: .address),
+      ]),
+    ]
+
+    let message: [String: ABI.Value] = [
+      "contents": .string("Hello, Bob!"),
+      "from": .tupleN([
+        .string("Cow"),
+        .address(try EthAddress("0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826")),
+      ]),
+      "to": .tupleN([
+        .string("Bob"),
+        .address(try EthAddress("0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB")),
+      ]),
+    ]
+
+    let typedData = ABI.EIP712.TypedData(
+      domain: domain,
+      types: types,
+      primaryType: "Mail",
+      message: message
+    )
+
+    let separator = try typedData.domainSeparator()
+    #expect(separator.hex == "0xf2cee375fa42b42143804025fc449deafd50cc031ca257e0b194a650a912090f")
+  }
+
+  // MARK: - Components Test
+
+  @Test("Get all EIP-712 components")
+  func testComponents() throws {
+    let domain = ABI.EIP712.Domain(
+      name: "Ether Mail",
+      version: "1",
+      chainId: 1,
+      verifyingContract: try EthAddress("0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC")
+    )
+
+    let types: [String: ABI.EIP712.TypeDefinition] = [
+      "Mail": .init(fields: [
+        .init(name: "from", type: .tuple([]), customType: "Person"),
+        .init(name: "to", type: .tuple([]), customType: "Person"),
+        .init(name: "contents", type: .string),
+      ]),
+      "Person": .init(fields: [
+        .init(name: "name", type: .string),
+        .init(name: "wallet", type: .address),
+      ]),
+    ]
+
+    let message: [String: ABI.Value] = [
+      "contents": .string("Hello, Bob!"),
+      "from": .tupleN([
+        .string("Cow"),
+        .address(try EthAddress("0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826")),
+      ]),
+      "to": .tupleN([
+        .string("Bob"),
+        .address(try EthAddress("0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB")),
+      ]),
+    ]
+
+    let typedData = ABI.EIP712.TypedData(
+      domain: domain,
+      types: types,
+      primaryType: "Mail",
+      message: message
+    )
+
+    let components = try typedData.components()
+
+    // Verify domain separator
+    #expect(
+      components.domainSeparator.hex
+        == "0xf2cee375fa42b42143804025fc449deafd50cc031ca257e0b194a650a912090f")
+    #expect(components.domainSeparator.data.count == 32)
+
+    // Verify hash struct
+    #expect(
+      components.hashStruct.hex
+        == "0xc52c0ee5d84264471806290a3f2c4cecfc5490626bf912d01f240d7a274b371e")
+    #expect(components.hashStruct.data.count == 32)
+
+    // Verify digest
+    let expectedEncoded = try typedData.encoded
+    let expectedDigest = Hex(SwiftKeccak.keccak256(expectedEncoded))
+    #expect(components.digest == expectedDigest)
+    #expect(components.digest.data.count == 32)
+
+    // Also verify the digest property directly
+    #expect(try typedData.digest == expectedDigest)
+  }
+
+  // MARK: - Full Encoding Tests
+
+  @Test("Encode Mail example")
+  func encodeMailExample() throws {
+    let domain = ABI.EIP712.Domain(
+      name: "Ether Mail",
+      version: "1",
+      chainId: 1,
+      verifyingContract: try EthAddress("0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC")
+    )
+
+    let types: [String: ABI.EIP712.TypeDefinition] = [
+      "Mail": .init(fields: [
+        .init(name: "from", type: .tuple([]), customType: "Person"),
+        .init(name: "to", type: .tuple([]), customType: "Person"),
+        .init(name: "contents", type: .string),
+      ]),
+      "Person": .init(fields: [
+        .init(name: "name", type: .string),
+        .init(name: "wallet", type: .address),
+      ]),
+    ]
+
+    let message: [String: ABI.Value] = [
+      "contents": .string("Hello, Bob!"),
+      "from": .tupleN([
+        .string("Cow"),
+        .address(try EthAddress("0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826")),
+      ]),
+      "to": .tupleN([
+        .string("Bob"),
+        .address(try EthAddress("0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB")),
+      ]),
+    ]
+
+    let typedData = ABI.EIP712.TypedData(
+      domain: domain,
+      types: types,
+      primaryType: "Mail",
+      message: message
+    )
+
+    let encoded = try typedData.encoded
+    #expect(
+      Hex(encoded).hex
+        == "0x1901f2cee375fa42b42143804025fc449deafd50cc031ca257e0b194a650a912090fc52c0ee5d84264471806290a3f2c4cecfc5490626bf912d01f240d7a274b371e"
+    )
+  }
+
+  @Test("Encode complex array")
+  func encodeComplexArray() throws {
+    let domain = ABI.EIP712.Domain(
+      name: "Complex Array",
+      version: "1",
+      chainId: 1,
+      verifyingContract: try EthAddress("0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC")
+    )
+
+    let types: [String: ABI.EIP712.TypeDefinition] = [
+      "Array": .init(fields: [
+        .init(name: "a", type: .uint256),
+        .init(name: "b", type: .uint256),
+        .init(name: "c", type: .string),
+        .init(name: "d", type: .array(.bytes)),
+      ])
+    ]
+
+    let message: [String: ABI.Value] = [
+      "a": .uint256(Number(55)),
+      "b": .uint256(Number(66)),
+      "c": .string("Hello"),
+      "d": .array(
+        .bytes,
+        [
+          .bytes(try Hex("0x1122")),
+          .bytes(try Hex("0x3344")),
+        ]),
+    ]
+
+    let typedData = ABI.EIP712.TypedData(
+      domain: domain,
+      types: types,
+      primaryType: "Array",
+      message: message
+    )
+
+    let encoded = try typedData.encoded
+    #expect(
+      Hex(encoded).hex
+        == "0x190103bd1627b4c5f7540c63d7ee347524dcef247eed29c833dd3b1455b8dec4009fcc95538bfc3f979ca59d9ef7de5ed402a4e403857b3de87d1fc8ed4a2a7cddd9"
+    )
+  }
+
+  @Test("Encode with bool field")
+  func encodeWithBool() throws {
+    let domain = ABI.EIP712.Domain(
+      name: "Complex Array",
+      version: "1"
+    )
+
+    let types: [String: ABI.EIP712.TypeDefinition] = [
+      "Array": .init(fields: [
+        .init(name: "a", type: .uint256),
+        .init(name: "b", type: .uint256),
+        .init(name: "c", type: .string),
+        .init(name: "d", type: .bool),
+      ])
+    ]
+
+    let message: [String: ABI.Value] = [
+      "a": .uint256(Number(55)),
+      "b": .uint256(Number(66)),
+      "c": .string("Hello"),
+      "d": .bool(true),
+    ]
+
+    let typedData = ABI.EIP712.TypedData(
+      domain: domain,
+      types: types,
+      primaryType: "Array",
+      message: message
+    )
+
+    let encoded = try typedData.encoded
+    #expect(
+      Hex(encoded).hex
+        == "0x1901f4806c1a9dae718712eca4906bfca239a3a4a6dea2e9b9a1284fee5ff4df4b1c8c56315a01fe3937526fe8c2b472b7e9e1c21728f6c14d5ffb0e0c156f74aca0"
+    )
+  }
+
+  @Test("Encode with minimal domain")
+  func encodeMinimalDomain() throws {
+    let domain = ABI.EIP712.Domain(
+      name: "Complex Array",
+      version: "1"
+    )
+
+    let types: [String: ABI.EIP712.TypeDefinition] = [
+      "Array": .init(fields: [
+        .init(name: "a", type: .uint256),
+        .init(name: "b", type: .uint256),
+        .init(name: "c", type: .string),
+        .init(name: "d", type: .array(.bytes)),
+      ])
+    ]
+
+    let message: [String: ABI.Value] = [
+      "a": .uint256(Number(55)),
+      "b": .uint256(Number(66)),
+      "c": .string("Hello"),
+      "d": .array(
+        .bytes,
+        [
+          .bytes(try Hex("0x1122")),
+          .bytes(try Hex("0x3344")),
+        ]),
+    ]
+
+    let typedData = ABI.EIP712.TypedData(
+      domain: domain,
+      types: types,
+      primaryType: "Array",
+      message: message
+    )
+
+    let encoded = try typedData.encoded
+    #expect(
+      Hex(encoded).hex
+        == "0x1901f4806c1a9dae718712eca4906bfca239a3a4a6dea2e9b9a1284fee5ff4df4b1ccc95538bfc3f979ca59d9ef7de5ed402a4e403857b3de87d1fc8ed4a2a7cddd9"
+    )
+  }
+
+  // MARK: - Domain Type Tests
+
+  @Test("Domain type with all fields")
+  func domainTypeWithAllFields() throws {
+    let domain = ABI.EIP712.Domain(
+      name: "Ether Mail",
+      version: "1",
+      chainId: 1,
+      verifyingContract: try EthAddress("0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"),
+      salt: try Hex("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+    )
+
+    let domainType = domain.domainType()
+    #expect(domainType.fields.count == 5)
+    #expect(domainType.fields[0].name == "name")
+    #expect(domainType.fields[0].type == .string)
+    #expect(domainType.fields[1].name == "version")
+    #expect(domainType.fields[1].type == .string)
+    #expect(domainType.fields[2].name == "chainId")
+    #expect(domainType.fields[2].type == .uint256)
+    #expect(domainType.fields[3].name == "verifyingContract")
+    #expect(domainType.fields[3].type == .address)
+    #expect(domainType.fields[4].name == "salt")
+    #expect(domainType.fields[4].type == .bytes32)
+  }
+
+  @Test("Domain type with partial fields")
+  func domainTypePartialFields() throws {
+    let domain = ABI.EIP712.Domain(
+      name: "Ether Mail",
+      version: "1"
+    )
+
+    let domainType = domain.domainType()
+    #expect(domainType.fields.count == 2)
+    #expect(domainType.fields[0].name == "name")
+    #expect(domainType.fields[0].type == .string)
+    #expect(domainType.fields[1].name == "version")
+    #expect(domainType.fields[1].type == .string)
+  }
+
+  // MARK: - JSON Serialization Tests
+
+  @Test("JSON deserialization")
+  func jsonDeserialization() throws {
+    let json = """
+      {
+        "domain": {
+          "name": "Ether Mail",
+          "version": "1",
+          "chainId": 1,
+          "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        "types": {
+          "Person": [
+            {
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "name": "wallet",
+              "type": "address"
+            }
+          ],
+          "Mail": [
+            {
+              "name": "from",
+              "type": "Person"
+            },
+            {
+              "name": "to",
+              "type": "Person"
+            },
+            {
+              "name": "contents",
+              "type": "string"
+            }
+          ]
+        },
+        "primaryType": "Mail",
+        "message": {
+          "from": {
+            "name": "Cow",
+            "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+          },
+          "to": {
+            "name": "Bob",
+            "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+          },
+          "contents": "Hello, Bob!"
+        }
+      }
+      """
+
+    let typedData = try ABI.EIP712.TypedData(jsonString: json)
+
+    // Verify domain
+    #expect(typedData.domain.name == "Ether Mail")
+    #expect(typedData.domain.version == "1")
+    #expect(typedData.domain.chainId == 1)
+    #expect(typedData.domain.verifyingContract?.hex == "0xcccccccccccccccccccccccccccccccccccccccc")
+
+    // Verify types
+    #expect(typedData.types.count == 2)
+    #expect(typedData.types["Person"]?.fields.count == 2)
+    #expect(typedData.types["Mail"]?.fields.count == 3)
+
+    // Verify primary type
+    #expect(typedData.primaryType == "Mail")
+
+    // Verify message
+    #expect(typedData.message["contents"]?.asString == "Hello, Bob!")
+
+    // Verify encoding matches expected
+    let encoded = try typedData.encoded
+    #expect(
+      Hex(encoded).hex
+        == "0x1901f2cee375fa42b42143804025fc449deafd50cc031ca257e0b194a650a912090fc52c0ee5d84264471806290a3f2c4cecfc5490626bf912d01f240d7a274b371e"
+    )
+  }
+
+  @Test("JSON round-trip serialization")
+  func jsonSerialization() throws {
+    let domain = ABI.EIP712.Domain(
+      name: "Ether Mail",
+      version: "1",
+      chainId: 1,
+      verifyingContract: try EthAddress("0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC")
+    )
+
+    let types: [String: ABI.EIP712.TypeDefinition] = [
+      "Mail": .init(fields: [
+        .init(name: "from", type: .tuple([]), customType: "Person"),
+        .init(name: "to", type: .tuple([]), customType: "Person"),
+        .init(name: "contents", type: .string),
+      ]),
+      "Person": .init(fields: [
+        .init(name: "name", type: .string),
+        .init(name: "wallet", type: .address),
+      ]),
+    ]
+
+    let message: [String: ABI.Value] = [
+      "contents": .string("Hello, Bob!"),
+      "from": .tupleN([
+        .string("Cow"),
+        .address(try EthAddress("0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826")),
+      ]),
+      "to": .tupleN([
+        .string("Bob"),
+        .address(try EthAddress("0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB")),
+      ]),
+    ]
+
+    let typedData = ABI.EIP712.TypedData(
+      domain: domain,
+      types: types,
+      primaryType: "Mail",
+      message: message
+    )
+
+    // Serialize to JSON and back
+    let jsonData = try typedData.jsonData()
+    let deserialized = try ABI.EIP712.TypedData(jsonData: jsonData)
+
+    // Verify they produce the same encoding
+    let originalEncoded = try typedData.encoded
+    let deserializedEncoded = try deserialized.encoded
+    #expect(Hex(originalEncoded) == Hex(deserializedEncoded))
+  }
+
+  // MARK: - Type Value Encoding Tests
+
+  @Test("Encode address value")
+  func encodeDataValueAddress() throws {
+    let value = ABI.Value.address(try EthAddress("0x0000000000000000000000000000000000000001"))
+    let field = ABI.EIP712.TypeDefinition.Field(name: "addr", type: .address)
+    let encoded = try ABI.EIP712.TypedData.encodeValue(value: value, field: field, types: [:])
+
+    #expect(encoded.count == 32)
+    #expect(
+      Hex(encoded) == Hex("0x0000000000000000000000000000000000000000000000000000000000000001"))
+  }
+
+  @Test("Encode uint256 value")
+  func encodeDataValueUInt() throws {
+    let value = ABI.Value.uint256(Number(55))
+    let field = ABI.EIP712.TypeDefinition.Field(name: "num", type: .uint256)
+    let encoded = try ABI.EIP712.TypedData.encodeValue(value: value, field: field, types: [:])
+
+    #expect(encoded.count == 32)
+    #expect(Hex(encoded).hex.suffix(2) == "37")  // 55 in hex
+  }
+
+  @Test("Encode bytes32 value")
+  func encodeDataValueBytes32() throws {
+    let value = ABI.Value.bytes32(try Hex("0xCC"))
+    let field = ABI.EIP712.TypeDefinition.Field(name: "data", type: .bytes32)
+    let encoded = try ABI.EIP712.TypedData.encodeValue(value: value, field: field, types: [:])
+
+    #expect(encoded.count == 32)
+    #expect(Hex(encoded).hex.prefix(4) == "0xcc")
+  }
+
+  @Test("Encode bool values")
+  func encodeDataValueBool() throws {
+    let valueTrue = ABI.Value.bool(true)
+    let field = ABI.EIP712.TypeDefinition.Field(name: "flag", type: .bool)
+    let encodedTrue = try ABI.EIP712.TypedData.encodeValue(
+      value: valueTrue, field: field, types: [:])
+
+    #expect(encodedTrue.count == 32)
+    #expect(Hex(encodedTrue).hex.suffix(2) == "01")
+
+    let valueFalse = ABI.Value.bool(false)
+    let encodedFalse = try ABI.EIP712.TypedData.encodeValue(
+      value: valueFalse, field: field, types: [:])
+
+    #expect(encodedFalse.count == 32)
+    #expect(Hex(encodedFalse).hex.suffix(2) == "00")
+  }
+
+  @Test("Encode string value")
+  func encodeDataValueString() throws {
+    let value = ABI.Value.string("Cow")
+    let field = ABI.EIP712.TypeDefinition.Field(name: "name", type: .string)
+    let encoded = try ABI.EIP712.TypedData.encodeValue(value: value, field: field, types: [:])
+
+    let expected = Hex(SwiftKeccak.keccak256("Cow".data(using: .utf8)!))
+    #expect(Hex(encoded) == expected)
+  }
+
+  @Test("Encode dynamic bytes value")
+  func encodeDataValueBytes() throws {
+    let value = ABI.Value.bytes(try Hex("0xCCDD"))
+    let field = ABI.EIP712.TypeDefinition.Field(name: "data", type: .bytes)
+    let encoded = try ABI.EIP712.TypedData.encodeValue(value: value, field: field, types: [:])
+
+    let expected = try Hex("0x9014B850703629D30F5C8C6C86A6AD981AB9319997490629D7DA37E8CAE985A1")
+    #expect(Hex(encoded) == expected)
+  }
+
+  @Test("Encode array value")
+  func encodeDataValueArray() throws {
+    let value = ABI.Value.array(
+      .bytes,
+      [
+        .bytes(try Hex("0xCCDD")),
+        .bytes(try Hex("0xEE")),
+      ])
+    let field = ABI.EIP712.TypeDefinition.Field(name: "data", type: .array(.bytes))
+    let encoded = try ABI.EIP712.TypedData.encodeValue(value: value, field: field, types: [:])
+
+    let expected = try Hex("0x134619415A3C9FE841D99F7CFD5C0BCCFC7CF0DAE90743A3D717C748A3961CF5")
+    #expect(Hex(encoded) == expected)
+  }
+
+  // MARK: - Schema Parsing Tests
+
+  @Test("Parse canonical type strings")
+  func schemaFromCanonical() throws {
+    // Basic types
+    let (addressSchema, addressCustom) = try ABI.Schema.fromCanonical("address")
+    #expect(addressSchema == .address)
+    #expect(addressCustom == nil)
+
+    let (uint256Schema, uint256Custom) = try ABI.Schema.fromCanonical("uint256")
+    #expect(uint256Schema == .uint256)
+    #expect(uint256Custom == nil)
+
+    let (bytes32Schema, bytes32Custom) = try ABI.Schema.fromCanonical("bytes32")
+    #expect(bytes32Schema == .bytes32)
+    #expect(bytes32Custom == nil)
+
+    // Array types
+    let (arraySchema, arrayCustom) = try ABI.Schema.fromCanonical("uint256[]")
+    #expect(arraySchema == .array(.uint256))
+    #expect(arrayCustom == nil)
+
+    // Custom types
+    let (customSchema, customType) = try ABI.Schema.fromCanonical("Person")
+    #expect(customSchema == .tuple([]))
+    #expect(customType == "Person")
+
+    // Custom array types
+    let (customArraySchema, customArrayType) = try ABI.Schema.fromCanonical("Person[]")
+    #expect(customArraySchema == .array(.tuple([])))
+    #expect(customArrayType == "Person[]")
+  }
+
+  // MARK: - Error Cases
+
+  @Test("Missing type error")
+  func missingType() throws {
+    let types: [String: ABI.EIP712.TypeDefinition] = [:]
+
+    #expect(throws: ABI.EIP712.Error.missingType("NonExistent")) {
+      try ABI.EIP712.encodeType("NonExistent", types: types)
+    }
+  }
+
+  @Test("Missing field error")
+  func missingField() throws {
+    let types: [String: ABI.EIP712.TypeDefinition] = [
+      "Test": .init(fields: [
+        .init(name: "field1", type: .string)
+      ])
+    ]
+
+    let value: [String: ABI.Value] = [:]  // Missing field1
+
+    #expect(throws: ABI.EIP712.Error.missingField(typeName: "Test", fieldName: "field1")) {
+      try ABI.EIP712.TypedData.hashStruct(typeName: "Test", data: value, types: types)
+    }
+  }
+
+  @Test("Mismatched value type error")
+  func invalidValueType() throws {
+    let value = ABI.Value.string("not an address")
+    let field = ABI.EIP712.TypeDefinition.Field(name: "addr", type: .address)
+
+    #expect(throws: ABI.EIP712.Error.mismatchedValueType(expected: "address", actual: "string")) {
+      try ABI.EIP712.TypedData.encodeValue(value: value, field: field, types: [:])
+    }
+  }
+}


### PR DESCRIPTION
  Implement full EIP-712 specification based on working Elixir implementation, providing a clean Swift interface with proper type safety and developer ergonomics.

  Key changes:
  - Add EIP712.swift with TypedData, Domain, and TypeDefinition types
  - Implement encoding methods using existing ABI infrastructure
  - Add Schema+Decode.swift for parsing canonical type strings
  - Add JSONValue.swift as a public type-safe JSON representation
  - Support custom struct types via tuple placeholders with customType field
  - Implement proper EIP-712 encoding rules (dynamic types hashed, static types 32-byte encoded)
  - Add comprehensive test suite with 22 tests covering all functionality
  - Support JSON serialization/deserialization for typed data
  - Use computed property encoded for clean API

  The implementation leverages existing ABI encoder/decoder rather than reimplementing functionality, and follows Swift best practices for error handling and type safety.

  🤖 Generated with https://claude.ai/code

  Co-Authored-By: Claude mailto:noreply@anthropic.com