### PR TITLE
Improve toHex performance

### DIFF
--- a/Sources/Eth/Hex.swift
+++ b/Sources/Eth/Hex.swift
@@ -174,7 +174,16 @@ public struct Hex: Codable, Equatable, Hashable, CustomStringConvertible, Expres
      * - Returns: A hexadecimal string representation of the `Data` with a `0x` prefix.
      */
     public static func toHex(_ data: Data) -> String {
-        return "0x" + data.map { String(format: "%02x", $0) }.joined()
+       let hexChars = Array("0123456789abcdef")
+       var result = "0x"
+       result.reserveCapacity(2 + data.count * 2)
+
+       for byte in data {
+           result.append(hexChars[Int(byte >> 4)])
+           result.append(hexChars[Int(byte & 0x0F)])
+       }
+
+       return result
     }
 
     /**


### PR DESCRIPTION
This significantly (~6x) improves the performance of encoding Hex. The old implementation allocated a string for every byte of hex and joined them. This new approach pre-allocates memory for the entire hex. 

Tested like this where we encode an array of 10000 addresses
```swift
func testPerformance() {
    let addresses = (0 ..< 10000).map { _ in
        EthAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f3e842")
    }

    measure {
        let encoder = JSONEncoder()
        _ = try? encoder.encode(addresses)
    }
}
```

Results before change: 
```
Test Case '-[EthTests.EthAddressTests testPerformance]' measured [Time, seconds] average: 0.113, relative standard deviation: 7.950%, values: [0.140103, 0.109930, 0.111340, 0.110805, 0.110269, 0.109016, 0.109805, 0.109085, 0.109880, 0.112113], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "", baselineAverage: , polarity: prefers smaller, maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100
```

Results after change:
```
Test Case '-[EthTests.EthAddressTests testPerformance]' measured [Time, seconds] average: 0.017, relative standard deviation: 16.759%, values: [0.025928, 0.018557, 0.017002, 0.016746, 0.016543, 0.016298, 0.015993, 0.015710, 0.015918, 0.015955], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "", baselineAverage: , polarity: prefers smaller, maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100
```